### PR TITLE
Add RTOSAL Interrupt support

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037" moduleId="org.eclipse.cdt.core.settings" name="FreeRTOS-RISCV">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037" name="FreeRTOS-RISCV" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037.233578961" name="/" resourcePath="">
+						<toolChain id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.98672301" name="RISC-V Cross GCC" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base">
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix.1301000673" name="Prefix" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix" value="riscv64-unknown-elf-" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.suffix.260677271" name="Suffix" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.suffix"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.c.50480976" name="C compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.c" value="gcc" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.cpp.107638989" name="C++ compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.cpp" value="g++" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.ar.1310857009" name="Archiver" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.ar" value="ar" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objcopy.1304533349" name="Hex/Bin converter" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objcopy" value="objcopy" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objdump.1998249454" name="Listing generator" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objdump" value="objdump" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.size.1482701963" name="Size command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.size" value="size" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.make.60579724" name="Build command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.make" value="make" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.rm.1755218129" name="Remove command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.rm" value="rm" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.useglobalpath.406026144" name="Use global path" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.useglobalpath"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.path.388305300" name="Path" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.path"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createflash.856976433" name="Create flash image" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createflash" value="true" valueType="boolean"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createlisting.1041902520" name="Create extended listing" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createlisting"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.printsize.900378942" name="Print size" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.printsize" value="true" valueType="boolean"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.base.1767477162" name="Architecture" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.base"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.multiply.161082400" name="Multiply extension (RVM)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.multiply"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.atomic.442293225" name="Atomic extension (RVA)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.atomic"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.fp.286894970" name="Floating point" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.fp"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.compressed.1396364998" name="Compressed extension (RVC)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.compressed"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.integer.1985014909" name="Integer ABI" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.integer"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.fp.2128235081" name="Floating point ABI" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.fp"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.tune.962836699" name="Tuning" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.tune"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.codemodel.540959881" name="Code model" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.codemodel"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.smalldatalimit.2045669487" name="Small data limit" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.smalldatalimit"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.align.1584491559" name="Align" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.align"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.saverestore.327179713" name="Small prologue/epilogue (-msave-restore)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.saverestore"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.memcpy.521209216" name="Force string operations to call library functions (-mmemcpy)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.memcpy"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.plt.1985536670" name="Allow use of PLTs (-mplt)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.plt"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.fdiv.1337232447" name="Floating-point divide/sqrt instructions (-mfdiv)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.fdiv"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.div.1258048689" name="Integer divide instructions (-mdiv)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.div"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other.294852421" name="Other target flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.level.380373540" name="Optimization Level" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.level"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.messagelength.1369917309" name="Message length (-fmessage-length=0)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.messagelength"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.signedchar.749811583" name="'char' is signed (-fsigned-char)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.signedchar"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.functionsections.1190946132" name="Function sections (-ffunction-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.functionsections"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.datasections.27683779" name="Data sections (-fdata-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.datasections"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nocommon.1372821692" name="No common unitialized (-fno-common)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nocommon"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.noinlinefunctions.1635654851" name="Do not inline functions (-fno-inline-functions)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.noinlinefunctions"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.freestanding.197018706" name="Assume freestanding environment (-ffreestanding)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.freestanding"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nobuiltin.931592579" name="Disable builtin (-fno-builtin)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nobuiltin"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.spconstant.1205240315" name="Single precision constants (-fsingle-precision-constant)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.spconstant"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.PIC.142901698" name="Position independent code (-fPIC)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.PIC"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.lto.824380463" name="Link-time optimizer (-flto)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.lto"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nomoveloopinvariants.558116457" name="Disable loop invariant move (-fno-move-loop-invariants)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nomoveloopinvariants"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.other.2072124125" name="Other optimization flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.name.725876507" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.name" value="GNU MCU RISC-V GCC" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.id.1208984656" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.id" value="512258282" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.syntaxonly.1191624906" name="Check syntax only (-fsyntax-only)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.syntaxonly"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedantic.780566513" name="Pedantic (-pedantic)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedantic"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedanticerrors.1751459266" name="Pedantic warnings as errors (-pedantic-errors)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedanticerrors"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.nowarn.549625820" name="Inhibit all warnings (-w)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.nowarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.unused.1547961693" name="Warn on various unused elements (-Wunused)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.unused"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.uninitialized.1033589484" name="Warn on uninitialized variables (-Wuninitialised)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.uninitialized"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.allwarn.1123897872" name="Enable all common warnings (-Wall)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.allwarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.extrawarn.1348935379" name="Enable extra warnings (-Wextra)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.extrawarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.missingdeclaration.1293275377" name="Warn on undeclared global function (-Wmissing-declaration)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.missingdeclaration"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.conversion.539635013" name="Warn on implicit conversions (-Wconversion)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.conversion"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pointerarith.706975505" name="Warn if pointer arithmetic (-Wpointer-arith)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pointerarith"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.padded.558607488" name="Warn if padding is included (-Wpadded)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.padded"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.shadow.1252375869" name="Warn if shadowed variable (-Wshadow)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.shadow"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.logicalop.534488807" name="Warn if suspicious logical ops (-Wlogical-op)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.logicalop"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.agreggatereturn.871564755" name="Warn if struct is returned (-Wagreggate-return)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.agreggatereturn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.floatequal.1782324806" name="Warn if floats are compared as equal (-Wfloat-equal)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.floatequal"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.toerrors.509708781" name="Generate errors instead of warnings (-Werror)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.toerrors"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.other.1846977446" name="Other warning flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.level.202970090" name="Debug level" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.level"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.format.1524967709" name="Debug format" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.format"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.prof.468450045" name="Generate prof information (-p)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.prof"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.gprof.454312857" name="Generate gprof information (-pg)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.gprof"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.other.1123531119" name="Other debugging flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.showDevicesTab.1682358874" name="showDevicesTab" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.showDevicesTab"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="ilg.gnumcueclipse.managedbuild.cross.riscv.targetPlatform.1385827490" isAbstract="false" osList="all" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.targetPlatform"/>
+							<builder buildPath="${workspace_loc:/riscv-fw-infrastructure/WD-Firmware/examples/build}" cleanBuildTarget="-c target=hifive1 example=ex-freertos" command="scons" id="ilg.gnumcueclipse.managedbuild.cross.riscv.builder.1855410906" incrementalBuildTarget="target=hifive1 example=ex-freertos" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.builder"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.687028150" name="GNU RISC-V Cross Assembler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.assembler.usepreprocessor.326488470" name="Use preprocessor" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.assembler.usepreprocessor" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input.446852242" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.1267566911" name="GNU RISC-V Cross C Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler">
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input.911559839" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.1000416522" name="GNU RISC-V Cross C++ Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler">
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input.1047730935" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.linker.191133457" name="GNU RISC-V Cross C Linker" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.linker">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.linker.gcsections.272170565" name="Remove unused sections (-Xlinker --gc-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.linker.gcsections" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.1006072422" name="GNU RISC-V Cross C++ Linker" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.gcsections.779284834" name="Remove unused sections (-Xlinker --gc-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.gcsections" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.input.1352274328" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.archiver.1716241218" name="GNU RISC-V Cross Archiver" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.archiver"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createflash.1412915860" name="GNU RISC-V Cross Create Flash Image" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createflash"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createlisting.1411973133" name="GNU RISC-V Cross Create Listing" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createlisting">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.source.29466984" name="Display source (--source|-S)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.source" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.allheaders.476893886" name="Display all headers (--all-headers|-x)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.allheaders" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.demangle.1876336242" name="Demangle names (--demangle|-C)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.demangle" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.linenumbers.1148731437" name="Display line numbers (--line-numbers|-l)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.linenumbers" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.wide.1531990459" name="Wide lines (--wide|-w)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.wide" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.printsize.1788211029" name="GNU RISC-V Cross Print Size" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.printsize">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.format.1732129111" name="Size format" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.format" useByScannerDiscovery="false"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+		<cconfiguration id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037.1050763906">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037.1050763906" moduleId="org.eclipse.cdt.core.settings" name="comrv-baremetal">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037.1050763906" name="comrv-baremetal" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037.1050763906." name="/" resourcePath="">
+						<toolChain id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.337743277" name="RISC-V Cross GCC" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base">
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix.312703083" name="Prefix" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix" value="riscv64-unknown-elf-" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.suffix.488304645" name="Suffix" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.suffix"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.c.407025579" name="C compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.c" value="gcc" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.cpp.851863719" name="C++ compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.cpp" value="g++" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.ar.1625814642" name="Archiver" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.ar" value="ar" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objcopy.1153020470" name="Hex/Bin converter" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objcopy" value="objcopy" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objdump.841254569" name="Listing generator" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objdump" value="objdump" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.size.1135892176" name="Size command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.size" value="size" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.make.669315339" name="Build command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.make" value="make" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.rm.1113500012" name="Remove command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.rm" value="rm" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.useglobalpath.1975001262" name="Use global path" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.useglobalpath"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.path.89703603" name="Path" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.path"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createflash.398332680" name="Create flash image" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createflash" value="true" valueType="boolean"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createlisting.887049857" name="Create extended listing" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createlisting"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.printsize.297702881" name="Print size" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.printsize" value="true" valueType="boolean"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.base.2063736994" name="Architecture" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.base"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.multiply.1436960106" name="Multiply extension (RVM)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.multiply"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.atomic.47098919" name="Atomic extension (RVA)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.atomic"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.fp.487636591" name="Floating point" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.fp"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.compressed.691426203" name="Compressed extension (RVC)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.compressed"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.integer.836185449" name="Integer ABI" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.integer"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.fp.796116341" name="Floating point ABI" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.fp"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.tune.1714149336" name="Tuning" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.tune"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.codemodel.1509466495" name="Code model" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.codemodel"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.smalldatalimit.1389821765" name="Small data limit" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.smalldatalimit"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.align.2066037038" name="Align" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.align"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.saverestore.46283118" name="Small prologue/epilogue (-msave-restore)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.saverestore"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.memcpy.799239894" name="Force string operations to call library functions (-mmemcpy)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.memcpy"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.plt.1922747958" name="Allow use of PLTs (-mplt)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.plt"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.fdiv.149911685" name="Floating-point divide/sqrt instructions (-mfdiv)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.fdiv"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.div.136040608" name="Integer divide instructions (-mdiv)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.div"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other.1218414434" name="Other target flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.level.31678118" name="Optimization Level" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.level"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.messagelength.1874758058" name="Message length (-fmessage-length=0)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.messagelength"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.signedchar.280563224" name="'char' is signed (-fsigned-char)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.signedchar"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.functionsections.1941192742" name="Function sections (-ffunction-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.functionsections"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.datasections.593994902" name="Data sections (-fdata-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.datasections"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nocommon.434224501" name="No common unitialized (-fno-common)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nocommon"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.noinlinefunctions.2042338505" name="Do not inline functions (-fno-inline-functions)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.noinlinefunctions"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.freestanding.1294100407" name="Assume freestanding environment (-ffreestanding)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.freestanding"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nobuiltin.494905502" name="Disable builtin (-fno-builtin)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nobuiltin"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.spconstant.2146481307" name="Single precision constants (-fsingle-precision-constant)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.spconstant"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.PIC.857653214" name="Position independent code (-fPIC)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.PIC"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.lto.2033081423" name="Link-time optimizer (-flto)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.lto"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nomoveloopinvariants.113407467" name="Disable loop invariant move (-fno-move-loop-invariants)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nomoveloopinvariants"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.other.138547823" name="Other optimization flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.name.1389768585" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.name" value="GNU MCU RISC-V GCC" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.id.1434611149" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.id" value="512258282" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.syntaxonly.1830175078" name="Check syntax only (-fsyntax-only)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.syntaxonly"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedantic.420592086" name="Pedantic (-pedantic)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedantic"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedanticerrors.1014160523" name="Pedantic warnings as errors (-pedantic-errors)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedanticerrors"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.nowarn.262444945" name="Inhibit all warnings (-w)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.nowarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.unused.557725791" name="Warn on various unused elements (-Wunused)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.unused"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.uninitialized.402605693" name="Warn on uninitialized variables (-Wuninitialised)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.uninitialized"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.allwarn.537327765" name="Enable all common warnings (-Wall)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.allwarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.extrawarn.1127846897" name="Enable extra warnings (-Wextra)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.extrawarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.missingdeclaration.715696188" name="Warn on undeclared global function (-Wmissing-declaration)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.missingdeclaration"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.conversion.2145446577" name="Warn on implicit conversions (-Wconversion)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.conversion"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pointerarith.1602209472" name="Warn if pointer arithmetic (-Wpointer-arith)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pointerarith"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.padded.1400917989" name="Warn if padding is included (-Wpadded)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.padded"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.shadow.535757454" name="Warn if shadowed variable (-Wshadow)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.shadow"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.logicalop.769969648" name="Warn if suspicious logical ops (-Wlogical-op)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.logicalop"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.agreggatereturn.867072416" name="Warn if struct is returned (-Wagreggate-return)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.agreggatereturn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.floatequal.926999414" name="Warn if floats are compared as equal (-Wfloat-equal)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.floatequal"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.toerrors.632812674" name="Generate errors instead of warnings (-Werror)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.toerrors"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.other.983622269" name="Other warning flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.level.213224330" name="Debug level" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.level"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.format.931996511" name="Debug format" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.format"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.prof.1484400137" name="Generate prof information (-p)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.prof"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.gprof.246087812" name="Generate gprof information (-pg)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.gprof"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.other.992317910" name="Other debugging flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.showDevicesTab.461158046" name="showDevicesTab" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.showDevicesTab"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="ilg.gnumcueclipse.managedbuild.cross.riscv.targetPlatform.802855403" isAbstract="false" osList="all" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.targetPlatform"/>
+							<builder buildPath="${workspace_loc:/riscv-fw-infrastructure/WD-Firmware/examples/build}" cleanBuildTarget="-c target=hifive1 example=ex-comrv-baremetal" command="scons" id="ilg.gnumcueclipse.managedbuild.cross.riscv.builder.1537019248" incrementalBuildTarget="target=hifive1 example=ex-comrv-baremetal" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.builder"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.1502378659" name="GNU RISC-V Cross Assembler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.assembler.usepreprocessor.1398981802" name="Use preprocessor" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.assembler.usepreprocessor" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input.538909139" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.1583086727" name="GNU RISC-V Cross C Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler">
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input.661968216" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.44047521" name="GNU RISC-V Cross C++ Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler">
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input.449500249" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.linker.627689341" name="GNU RISC-V Cross C Linker" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.linker">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.linker.gcsections.844513575" name="Remove unused sections (-Xlinker --gc-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.linker.gcsections" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.1288302597" name="GNU RISC-V Cross C++ Linker" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.gcsections.234670873" name="Remove unused sections (-Xlinker --gc-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.gcsections" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.input.972741212" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.archiver.1058008731" name="GNU RISC-V Cross Archiver" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.archiver"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createflash.1356332343" name="GNU RISC-V Cross Create Flash Image" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createflash"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createlisting.177946792" name="GNU RISC-V Cross Create Listing" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createlisting">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.source.1826265591" name="Display source (--source|-S)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.source" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.allheaders.939208757" name="Display all headers (--all-headers|-x)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.allheaders" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.demangle.364288587" name="Demangle names (--demangle|-C)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.demangle" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.linenumbers.599115601" name="Display line numbers (--line-numbers|-l)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.linenumbers" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.wide.643619068" name="Wide lines (--wide|-w)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.wide" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.printsize.1396656611" name="GNU RISC-V Cross Print Size" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.printsize">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.format.429446124" name="Size format" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.format" useByScannerDiscovery="false"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="riscv-fw-infrastructure.null.822621906" name="riscv-fw-infrastructure"/>
+	</storageModule>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="0.1734711697.2018791769">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037;ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037.233578961;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.1000416522;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input.1047730935">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037;ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.2135383037.233578961;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.1267566911;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input.911559839">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="0.1734711697">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="comrv-baremetal">
+			<resource resourceType="PROJECT" workspacePath="/riscv-fw-infrastructure"/>
+		</configuration>
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/riscv-fw-infrastructure"/>
+		</configuration>
+		<configuration configurationName="FreeRTOS-RISCV">
+			<resource resourceType="PROJECT" workspacePath="/riscv-fw-infrastructure"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+</cproject>

--- a/WD-Firmware/.cproject
+++ b/WD-Firmware/.cproject
@@ -2,7 +2,7 @@
 <?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
 	<storageModule moduleId="org.eclipse.cdt.core.settings">
 		<cconfiguration id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295" moduleId="org.eclipse.cdt.core.settings" name="Default">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295" moduleId="org.eclipse.cdt.core.settings" name="freertos">
 				<externalSettings/>
 				<extensions>
 					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
@@ -14,7 +14,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="${ProjName}" buildProperties="" description="" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+				<configuration artifactName="${ProjName}" buildProperties="" description="RISCV freertos demo using RTOS-AL" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295" name="freertos" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
 					<folderInfo id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.1096648574" name="/" resourcePath="">
 						<toolChain id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.175261499" name="RISC-V Cross GCC" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base">
 							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix.1882525389" name="Prefix" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix" value="riscv64-unknown-elf-" valueType="string"/>
@@ -96,6 +96,10 @@
 								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input.1719392974" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input"/>
 							</tool>
 							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.1134618641" name="GNU RISC-V Cross C Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.compiler.defs.869517631" name="Defined symbols (-D)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="D_USE_RTOSAL"/>
+									<listOptionValue builtIn="false" value="D_USE_FREERTOS"/>
+								</option>
 								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input.1400981216" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input"/>
 							</tool>
 							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.1249716764" name="GNU RISC-V Cross C++ Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler">
@@ -128,26 +132,167 @@
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+		<cconfiguration id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.678110434">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.678110434" moduleId="org.eclipse.cdt.core.settings" name="comrv-baremetal">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="RISCV comrv bare metal demo" id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.678110434" name="comrv-baremetal" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.678110434." name="/" resourcePath="">
+						<toolChain id="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.434331560" name="RISC-V Cross GCC" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base">
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix.1188864337" name="Prefix" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.prefix" value="riscv64-unknown-elf-" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.suffix.2072066774" name="Suffix" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.suffix"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.c.1660968252" name="C compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.c" value="gcc" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.cpp.1132244981" name="C++ compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.cpp" value="g++" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.ar.735315895" name="Archiver" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.ar" value="ar" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objcopy.2127626810" name="Hex/Bin converter" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objcopy" value="objcopy" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objdump.1565377403" name="Listing generator" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.objdump" value="objdump" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.size.1997156637" name="Size command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.size" value="size" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.make.8440274" name="Build command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.make" value="make" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.rm.360384320" name="Remove command" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.command.rm" value="rm" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.useglobalpath.1419501664" name="Use global path" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.useglobalpath"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.path.1693461579" name="Path" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.path"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createflash.1189237289" name="Create flash image" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createflash" value="true" valueType="boolean"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createlisting.187496638" name="Create extended listing" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.createlisting"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.printsize.796188509" name="Print size" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.addtools.printsize" value="true" valueType="boolean"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.base.1444992177" name="Architecture" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.base"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.multiply.1731313103" name="Multiply extension (RVM)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.multiply"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.atomic.1502903617" name="Atomic extension (RVA)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.atomic"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.fp.2118097484" name="Floating point" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.fp"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.compressed.553940753" name="Compressed extension (RVC)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.isa.compressed"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.integer.818103401" name="Integer ABI" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.integer"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.fp.873168968" name="Floating point ABI" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.abi.fp"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.tune.798672399" name="Tuning" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.tune"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.codemodel.1423254938" name="Code model" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.codemodel"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.smalldatalimit.1197118666" name="Small data limit" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.smalldatalimit"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.align.1695750882" name="Align" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.align"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.saverestore.695203923" name="Small prologue/epilogue (-msave-restore)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.saverestore"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.memcpy.1460726180" name="Force string operations to call library functions (-mmemcpy)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.memcpy"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.plt.246323781" name="Allow use of PLTs (-mplt)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.plt"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.fdiv.418598777" name="Floating-point divide/sqrt instructions (-mfdiv)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.fdiv"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.div.1133133791" name="Integer divide instructions (-mdiv)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.div"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other.290577591" name="Other target flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.target.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.level.908350836" name="Optimization Level" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.level"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.messagelength.799772389" name="Message length (-fmessage-length=0)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.messagelength"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.signedchar.2013379496" name="'char' is signed (-fsigned-char)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.signedchar"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.functionsections.1052898654" name="Function sections (-ffunction-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.functionsections"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.datasections.1048809243" name="Data sections (-fdata-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.datasections"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nocommon.1512306173" name="No common unitialized (-fno-common)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nocommon"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.noinlinefunctions.723641634" name="Do not inline functions (-fno-inline-functions)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.noinlinefunctions"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.freestanding.13199591" name="Assume freestanding environment (-ffreestanding)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.freestanding"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nobuiltin.1797676220" name="Disable builtin (-fno-builtin)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nobuiltin"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.spconstant.1437406542" name="Single precision constants (-fsingle-precision-constant)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.spconstant"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.PIC.1665191072" name="Position independent code (-fPIC)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.PIC"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.lto.141428995" name="Link-time optimizer (-flto)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.lto"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nomoveloopinvariants.1222192391" name="Disable loop invariant move (-fno-move-loop-invariants)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.nomoveloopinvariants"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.other.635674516" name="Other optimization flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.optimization.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.name.2138248662" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.name" value="RISC-V GCC/Newlib" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.id.392060037" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.toolchain.id" value="-2032619395" valueType="string"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.syntaxonly.2120745390" name="Check syntax only (-fsyntax-only)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.syntaxonly"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedantic.866403017" name="Pedantic (-pedantic)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedantic"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedanticerrors.416966283" name="Pedantic warnings as errors (-pedantic-errors)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pedanticerrors"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.nowarn.1934444459" name="Inhibit all warnings (-w)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.nowarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.unused.1703744970" name="Warn on various unused elements (-Wunused)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.unused"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.uninitialized.1359866725" name="Warn on uninitialized variables (-Wuninitialised)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.uninitialized"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.allwarn.1815779492" name="Enable all common warnings (-Wall)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.allwarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.extrawarn.839695437" name="Enable extra warnings (-Wextra)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.extrawarn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.missingdeclaration.1933361935" name="Warn on undeclared global function (-Wmissing-declaration)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.missingdeclaration"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.conversion.1217254329" name="Warn on implicit conversions (-Wconversion)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.conversion"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pointerarith.121210495" name="Warn if pointer arithmetic (-Wpointer-arith)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.pointerarith"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.padded.246948660" name="Warn if padding is included (-Wpadded)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.padded"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.shadow.2104534739" name="Warn if shadowed variable (-Wshadow)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.shadow"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.logicalop.1323047563" name="Warn if suspicious logical ops (-Wlogical-op)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.logicalop"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.agreggatereturn.1214394105" name="Warn if struct is returned (-Wagreggate-return)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.agreggatereturn"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.floatequal.1013907642" name="Warn if floats are compared as equal (-Wfloat-equal)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.floatequal"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.toerrors.467353525" name="Generate errors instead of warnings (-Werror)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.toerrors"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.other.748225171" name="Other warning flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.warnings.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.level.1771856795" name="Debug level" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.level"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.format.1624780643" name="Debug format" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.format"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.prof.1011582007" name="Generate prof information (-p)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.prof"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.gprof.2003266073" name="Generate gprof information (-pg)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.gprof"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.other.774781903" name="Other debugging flags" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.debugging.other"/>
+							<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.showDevicesTab.1790167513" name="showDevicesTab" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.showDevicesTab"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="ilg.gnumcueclipse.managedbuild.cross.riscv.targetPlatform.866159695" isAbstract="false" osList="all" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.targetPlatform"/>
+							<builder arguments="" autoBuildTarget="all" buildPath="${workspace_loc:/WD-Firmware/examples/build}" cleanBuildTarget="-c example=ex-comrv-baremetal target=hifive1" command="scons" enableAutoBuild="false" enableCleanBuild="true" enabledIncrementalBuild="true" id="ilg.gnumcueclipse.managedbuild.cross.riscv.builder.337150438" incrementalBuildTarget="example=ex-comrv-baremetal target=hifive1" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" parallelBuildOn="false" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.builder"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.2027978710" name="GNU RISC-V Cross Assembler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.assembler.usepreprocessor.1225014086" name="Use preprocessor" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.assembler.usepreprocessor" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input.414440050" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.assembler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.1381765000" name="GNU RISC-V Cross C Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.compiler.defs.811079291" name="Defined symbols (-D)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="D_USE_RTOSAL"/>
+									<listOptionValue builtIn="false" value="D_USE_FREERTOS"/>
+								</option>
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input.1526878076" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.122265818" name="GNU RISC-V Cross C++ Compiler" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler">
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input.365643030" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.linker.1353650624" name="GNU RISC-V Cross C Linker" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.linker">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.linker.gcsections.731628057" name="Remove unused sections (-Xlinker --gc-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.c.linker.gcsections" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.1039725536" name="GNU RISC-V Cross C++ Linker" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.gcsections.886075122" name="Remove unused sections (-Xlinker --gc-sections)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.cpp.linker.gcsections" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<inputType id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.input.477116857" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.archiver.139318356" name="GNU RISC-V Cross Archiver" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.archiver"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createflash.1313279324" name="GNU RISC-V Cross Create Flash Image" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createflash"/>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createlisting.1967748950" name="GNU RISC-V Cross Create Listing" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.createlisting">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.source.1835592678" name="Display source (--source|-S)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.source" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.allheaders.1850047159" name="Display all headers (--all-headers|-x)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.allheaders" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.demangle.295606325" name="Demangle names (--demangle|-C)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.demangle" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.linenumbers.40477655" name="Display line numbers (--line-numbers|-l)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.linenumbers" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.wide.1558892349" name="Wide lines (--wide|-w)" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.createlisting.wide" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+							</tool>
+							<tool id="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.printsize.1395812447" name="GNU RISC-V Cross Print Size" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.tool.printsize">
+								<option id="ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.format.242529451" name="Size format" superClass="ilg.gnumcueclipse.managedbuild.cross.riscv.option.printsize.format" useByScannerDiscovery="false"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-		<project id="WD-Firmware.null.731020170" name="WD-Firmware"/>
-	</storageModule>
-	<storageModule moduleId="scannerConfiguration">
-		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		<scannerConfigBuildInfo instanceId="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295;ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.1096648574;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.1249716764;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input.1935214354">
-			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295;ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.1096648574;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.1134618641;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input.1400981216">
-			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
-		</scannerConfigBuildInfo>
+		<project id="WD-Firmware.null.1634379101" name="WD-Firmware"/>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="comrv-baremetal"/>
 		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/WD-Firmware"/>
+		</configuration>
+		<configuration configurationName="freertos">
 			<resource resourceType="PROJECT" workspacePath="/WD-Firmware"/>
 		</configuration>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295;ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.1096648574;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.1134618641;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.c.compiler.input.1400981216">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="0.1320279205">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295;ilg.gnumcueclipse.managedbuild.cross.riscv.toolchain.base.1104884295.1096648574;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.1249716764;ilg.gnumcueclipse.managedbuild.cross.riscv.tool.cpp.compiler.input.1935214354">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
 </cproject>

--- a/WD-Firmware/board/hifive-1/FreeRTOSConfig.h
+++ b/WD-Firmware/board/hifive-1/FreeRTOSConfig.h
@@ -151,10 +151,10 @@ your application. */
 #define INCLUDE_xTaskGetCurrentTaskHandle       1
 #define INCLUDE_uxTaskGetStackHighWaterMark     1
 #define INCLUDE_xTaskGetIdleTaskHandle          1
-#define INCLUDE_eTaskGetState                   0
+#define INCLUDE_eTaskGetState                   1
 #define INCLUDE_xEventGroupSetBitFromISR        1
 #define INCLUDE_xTimerPendFunctionCall          1
-#define INCLUDE_xTaskAbortDelay                 0
+#define INCLUDE_xTaskAbortDelay                 1
 #define INCLUDE_xTaskGetHandle                  1
 #define INCLUDE_xTaskResumeFromISR              1
 

--- a/WD-Firmware/board/hifive-1/bsp/env/freedom-e300-hifive1/init.c
+++ b/WD-Firmware/board/hifive-1/bsp/env/freedom-e300-hifive1/init.c
@@ -6,7 +6,13 @@
 #include "platform.h"
 #include "encoding.h"
 
-extern void trap_entry();
+#ifdef D_USE_RTOSAL
+  extern void rtosal_vect_table();
+#elif defined(D_BARE_METAL)
+  extern void psp_vect_table();
+#else
+  extern void trap_entry();
+#endif
 
 static unsigned long mtime_lo(void)
 {
@@ -229,7 +235,14 @@ void _init()
  write(1, freq_string, 9);
  write(1, "Hz\n",3);
 
+#ifdef D_USE_RTOSAL
+  write_csr(mtvec, &rtosal_vect_table);
+#elif defined(D_BARE_METAL)
+  write_csr(mtvec, &psp_vect_table);
+#else
   write_csr(mtvec, &trap_entry);
+#endif
+
   if (read_csr(misa) & (1 << ('F' - 'A'))) { // if F extension is present
     write_csr(mstatus, MSTATUS_FS); // allow FPU instructions without trapping
     write_csr(fcsr, 0); // initialize rounding mode, undefined at reset

--- a/WD-Firmware/comrv/api_inc/comrv_api.h
+++ b/WD-Firmware/comrv/api_inc/comrv_api.h
@@ -1,13 +1,13 @@
-/* 
+/*
 * SPDX-License-Identifier: Apache-2.0
 * Copyright 2019 Western Digital Corporation or its affiliates.
-* 
+*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
-* 
+*
 * http:*www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,20 +15,17 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   comrv_api.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
-* 
+* @date   11.06.2019
+* @brief  The file defines the COM RV interfaces
 */
+#ifndef __COMRV_TASK_API_H__
+#define __COMRV_TASK_API_H__
 
 /**
 * include files
 */
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
 
 /**
 * definitions
@@ -55,16 +52,7 @@
 */
 
 /**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
+* APIs
 */
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
 
+#endif /* __COMRV_TASK_API_H__ */

--- a/WD-Firmware/comrv/api_inc/comrv_config.h
+++ b/WD-Firmware/comrv/api_inc/comrv_config.h
@@ -15,56 +15,18 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   comrv_config.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
-* 
+* @date   11.06.2019
+* @brief  The file defines the COM-RV configuration
 */
 
 /**
 * include files
 */
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
 
 /**
 * definitions
 */
 
-/**
-* macros
-*/
-
-/**
-* types
-*/
-
-/**
-* local prototypes
-*/
-
-/**
-* external prototypes
-*/
-
-/**
-* global variables
-*/
-
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-
+#endif /* __COMRV_CONFIG_H__ */

--- a/WD-Firmware/comrv/api_inc/comrv_defines.h
+++ b/WD-Firmware/comrv/api_inc/comrv_defines.h
@@ -15,56 +15,21 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   rtosal_defines.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
+* @date   11.06.2019
+* @brief  The COM-RV defines
 * 
 */
+#ifndef  __COMRV_DEFINES_H__
+#define  __COMRV_DEFINES_H__
 
 /**
 * include files
 */
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
 
 /**
 * definitions
 */
 
-/**
-* macros
-*/
-
-/**
-* types
-*/
-
-/**
-* local prototypes
-*/
-
-/**
-* external prototypes
-*/
-
-/**
-* global variables
-*/
-
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-
+#endif /* __COMRV_DEFINES_H__ */

--- a/WD-Firmware/comrv/api_inc/comrv_macro.h
+++ b/WD-Firmware/comrv/api_inc/comrv_macro.h
@@ -1,13 +1,13 @@
-/* 
+/*
 * SPDX-License-Identifier: Apache-2.0
 * Copyright 2019 Western Digital Corporation or its affiliates.
-* 
+*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
-* 
+*
 * http:*www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,56 +15,20 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   rtosal_macro.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
-* 
+* @date   11.06.2019
+* @brief  The file defines the COM-RV macros
 */
+#ifndef __COMRV_MACRO_H__
+#define __COMRV_MACRO_H__
 
 /**
 * include files
-*/
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
-
-/**
-* definitions
 */
 
 /**
 * macros
 */
 
-/**
-* types
-*/
-
-/**
-* local prototypes
-*/
-
-/**
-* external prototypes
-*/
-
-/**
-* global variables
-*/
-
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-
+#endif /* __COMRV_MACRO_H__ */

--- a/WD-Firmware/comrv/api_inc/comrv_types.h
+++ b/WD-Firmware/comrv/api_inc/comrv_types.h
@@ -15,56 +15,22 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   comrv_types.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
+* @date   11.06.2019
+* @brief  The defines RTOS AL specific types
 * 
 */
+#ifndef  __COMRV_TYPES_H__
+#define  __COMRV_TYPES_H__
 
 /**
 * include files
-*/
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
-
-/**
-* definitions
-*/
-
-/**
-* macros
 */
 
 /**
 * types
 */
 
-/**
-* local prototypes
-*/
 
-/**
-* external prototypes
-*/
-
-/**
-* global variables
-*/
-
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-
+#endif /* __COMRV_TYPES_H__ */

--- a/WD-Firmware/comrv/comrv.c
+++ b/WD-Firmware/comrv/comrv.c
@@ -15,20 +15,16 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   comrv.c
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
+* @date   21.06.2019
+* @brief  The file implements the COM-RV interfaces
 * 
 */
 
 /**
 * include files
 */
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
 
 /**
 * definitions
@@ -53,18 +49,3 @@
 /**
 * global variables
 */
-
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-

--- a/WD-Firmware/comrv/comrv_asm.S
+++ b/WD-Firmware/comrv/comrv_asm.S
@@ -1,13 +1,13 @@
-/* 
+/*
 * SPDX-License-Identifier: Apache-2.0
 * Copyright 2019 Western Digital Corporation or its affiliates.
-* 
+*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
-* 
+*
 * http:*www.apache.org/licenses/LICENSE-2.0
-* 
+*
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,28 +15,12 @@
 * limitations under the License.
 */
 /**
-* @file   psp.c
+* @file   comrv.c
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the PSP API
-* 
+* @date   21.06.2019
+* @brief  The file implements the COM-RV interfaces
+*
 */
 
-/**
-* include files
-*/
-#include "common_types.h"
-#include "psp_api.h"
-
-/**
-* definitions
-*/
-
-/**
-* macros
-*/
-
-/**
-* types
-*/
+/*#include "psp_asm_macros.inc"*/
 

--- a/WD-Firmware/comrv/loc_inc/comrv.h
+++ b/WD-Firmware/comrv/loc_inc/comrv.h
@@ -15,20 +15,18 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   comrv.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
+* @date   11.06.2019
+* @brief  The defines COM-RV private interfaces
 * 
 */
+#ifndef  __COMRV_H__
+#define  __COMRV_H__
 
 /**
 * include files
 */
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
 
 /**
 * definitions
@@ -54,17 +52,4 @@
 * global variables
 */
 
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-
+#endif /* __COMRV_H__ */

--- a/WD-Firmware/examples/build/SConscript_bsp_hifive1
+++ b/WD-Firmware/examples/build/SConscript_bsp_hifive1
@@ -38,6 +38,7 @@ a_flags = [] + Env['A_FLAGS']
 
 # defines
 Env['BSP_DEF'] = ['_HIFIVE']
+c_defines = Env['RTOSAL_DEF'] + Env['BSP_DEF'] + Env['PUBLIC_DEF']
 
 # include paths
 include_paths = [ 
@@ -57,11 +58,11 @@ Env['LINKFLAGS'] += ['-T', os.path.join(Env['ROOT_DIR'], 'board', 'hifive-1', 'l
 # c file objects
 objects = []
 for list_file in list_files_c:
-  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=c_flags, CPPDEFINES=Env['BSP_DEF']))
+  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=c_flags, CPPDEFINES=c_defines))
 
 # asm file objects
 for list_file in list_files_a:
-  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=a_flags, CPPDEFINES=Env['BSP_DEF']))
+  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=a_flags, CPPDEFINES=c_defines))
 
 # for libraries
 bsp_lib = Env.Library (target=os.path.join(Env['OUT_DIR_PATH'], 'libs', 'bsp.a'), source=objects)

--- a/WD-Firmware/examples/build/SConscript_comrv_baremetal
+++ b/WD-Firmware/examples/build/SConscript_comrv_baremetal
@@ -1,0 +1,71 @@
+'''
+ SPDX-License-Identifier: Apache-2.0
+ Copyright 2019 Western Digital Corporation or its affiliates.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http:www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+'''
+import os
+Import('Env')
+
+#
+# This is a template file for adding a new module
+# Duplicate this file and replace module_name with your module name
+#   
+
+# module output directory 
+out_dir = os.path.join(Env['OUT_DIR_PATH'], 'comrv')
+if not os.path.exists(out_dir):
+    os.makedirs(out_dir)
+
+# list of c files to compile
+list_files_c=[
+#  ['location of c file to compile', 'location of resulting object file']
+   [os.path.join('comrv', 'comrv.c'), os.path.join(out_dir, 'comrv.o')],
+]
+
+# list of assembly files to compile
+list_files_a=[
+#  ['location of assembly file to compile', 'location of resulting object file']
+   [os.path.join('comrv', 'comrv_asm.S'), os.path.join(out_dir, 'comrv_asm.o')],
+]
+
+# compiler flags
+c_flags = [] + Env['C_FLAGS']
+a_flags = [] + Env['A_FLAGS']
+
+# defines
+Env['COMRV_DEF'] = []
+
+# include paths
+local_includes  = [os.path.join(Env['ROOT_DIR'], 'comrv', 'loc_inc'),]
+public_includes = [Env['PUBLIC_INC_PATH'], os.path.join(Env['ROOT_DIR'], 'comrv', 'api_inc'),]
+Env['COMRV_INC_PATH'] = public_includes
+include_paths = public_includes + local_includes
+
+# linker flags
+Env['LINKFLAGS'] += []
+
+# loop the list of c files and compile them
+objects = []
+for list_file in list_files_c:
+  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'],list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=c_flags, CPPDEFINES=Env['COMRV_DEF']))
+
+# loop the list of assembly files and compile them
+for list_file in list_files_a:
+  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=a_flags, CPPDEFINES=Env['COMRV_DEF']))
+
+# for libraries
+comrv_lib = Env.Library (target=os.path.join(Env['OUT_DIR_PATH'], 'libs', 'comrv.a'), source=objects)
+
+# return the comrv lib
+Return('comrv_lib')

--- a/WD-Firmware/examples/build/SConscript_example
+++ b/WD-Firmware/examples/build/SConscript_example
@@ -32,7 +32,7 @@ c_flags = [] + Env['C_FLAGS']
 a_flags = [] + Env['A_FLAGS']
 
 # defines
-c_defines = [Env['BSP_DEF'], Env['RTOSAL_DEF'], 'D_USE_RTOSAL']
+c_defines = Env['BSP_DEF'] + Env['PUBLIC_DEF'] + Env['RTOSAL_DEF']
 
 # include paths
 include_paths = [ 

--- a/WD-Firmware/examples/build/SConscript_freertos
+++ b/WD-Firmware/examples/build/SConscript_freertos
@@ -52,7 +52,7 @@ c_flags = [] + Env['C_FLAGS']
 a_flags = [] + Env['A_FLAGS']
 
 # defines
-c_defines = [] + Env['BSP_DEF']
+c_defines = Env['RTOSAL_DEF'] + Env['BSP_DEF'] + Env['PUBLIC_DEF']
 
 # include paths
 Env['RTOS_INC_PATH'] = [

--- a/WD-Firmware/examples/build/SConscript_psp
+++ b/WD-Firmware/examples/build/SConscript_psp
@@ -22,10 +22,13 @@ if not os.path.exists(out_dir):
     os.makedirs(out_dir)
 
 list_files_c=[
+   [os.path.join('psp','psp_interrupt.c'), os.path.join(out_dir, 'psp_interrupt.o')],
    [os.path.join('psp', 'psp.c'), os.path.join(out_dir, 'psp.o')],
 ]
 
-list_files_a=[]
+list_files_a=[
+[os.path.join('psp', 'psp_int_vect.S'), os.path.join(out_dir, 'psp_int_vect.o')],
+]
 
 # compiler flags
 c_flags = [] + Env['C_FLAGS']

--- a/WD-Firmware/examples/build/SConscript_rtosal
+++ b/WD-Firmware/examples/build/SConscript_rtosal
@@ -24,7 +24,6 @@ if not os.path.exists(out_dir):
 rtosal_base = os.path.join('rtos', 'rtosal')
 list_files_c=[
    [os.path.join(rtosal_base,'rtosal_event.c'), os.path.join(out_dir, 'rtosal_event.o')],
-   [os.path.join(rtosal_base,'rtosal_interrupt.c'), os.path.join(out_dir, 'rtosal_interrupt.o')],
    [os.path.join(rtosal_base,'rtosal_util.c'), os.path.join(out_dir, 'rtosal_util.o')],
    [os.path.join(rtosal_base,'rtosal_mutex.c'), os.path.join(out_dir, 'rtosal_mutex.o')],
    [os.path.join(rtosal_base,'rtosal_queue.c'), os.path.join(out_dir, 'rtosal_queue.o')],
@@ -35,7 +34,9 @@ list_files_c=[
 #   [os.path.join(rtosal_base,'rtosal_memory.c'), os.path.join(out_dir, 'rtosal_memory.o')],
 ]
 
-list_files_a=[]
+list_files_a=[
+   [os.path.join(rtosal_base,'rtosal_int_vect.S'), os.path.join(out_dir, 'rtosal_int_vect.o')],
+]
 
 rtos_core_define = {
   'freertos' :  ['D_USE_FREERTOS'],
@@ -47,7 +48,8 @@ c_flags = [] + Env['C_FLAGS']
 a_flags = [] + Env['A_FLAGS']
 
 # defines
-Env['RTOSAL_DEF'] = [] + rtos_core_define[Env['RTOS_CORE']]
+Env['RTOSAL_DEF'] = rtos_core_define[Env['RTOS_CORE']]
+c_defines = Env['BSP_DEF'] + Env['RTOSAL_DEF'] # add "+ ['D_RTOSAL_VECT_TABLE']" when using vector table
 
 # include paths
 local_includes  = [os.path.join(Env['ROOT_DIR'], rtosal_base, 'loc_inc'),]
@@ -63,14 +65,14 @@ Env['LINKFLAGS'] += []
 # for objects
 objects = []
 for list_file in list_files_c:
-  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=c_flags, CPPDEFINES=Env['RTOSAL_DEF']))
+  objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=c_flags, CPPDEFINES=c_defines))
 
 # asm file objects
 for list_file in list_files_a:
   objects.append(Env.Object(source=os.path.join(Env['ROOT_DIR'], list_file[0]), target=list_file[1], CPPPATH=include_paths, CCFLAGS=a_flags, CPPDEFINES=c_defines))
 
 # for libraries
-rtosal_lib = Env.Library (target=os.path.join(Env['OUT_DIR_PATH'],'libs', 'rtosal.a'), source=objects)
+rtosal_lib = Env.Library (target=os.path.join(Env['OUT_DIR_PATH'], 'libs', 'rtosal.a'), source=objects)
 
 #print Env.Dump()
 

--- a/WD-Firmware/examples/build/SConstruct
+++ b/WD-Firmware/examples/build/SConstruct
@@ -116,7 +116,8 @@ Env['RTOS_INC_PATH']   = []
 Env['BSP_INC_PATH']    = []
 Env['TARGET_LIBS']     = []
 Env['RTOS_CORE']       = []
-Env['PUBLIC_INC_PATH'] = [] 
+Env['PUBLIC_INC_PATH'] = []
+Env['PUBLIC_DEF']      = [] 
 Env['OUT_DIR_PATH']    = 'output'
 Env['TARGET_BOARD']    = tagretName
 Env['EXAMPLE_NAME']    = exampleName
@@ -164,13 +165,20 @@ Env['BUILDERS']['Size'] = size
 arr_lib              = []
 if exampleName == 'ex-freertos':
   Env['RTOS_CORE'] = 'freertos'
+  Env['PUBLIC_DEF']= ['D_USE_RTOSAL'] 
   arr_lib.append(SConscript('SConscript_bsp_'+ Env['TARGET_BOARD'], exports='Env'))
   arr_lib.append(SConscript('SConscript_'+ Env['RTOS_CORE'], exports='Env'))
   arr_lib.append(SConscript('SConscript_rtosal', exports='Env'))
   arr_lib.append(SConscript('SConscript_psp', exports='Env'))
   Env['TARGET_LIBS'] += ['c', 'gcc']
+elif exampleName == 'ex-comrv-baremetal':
+  Env['PUBLIC_DEF'] = ['D_BARE_METAL'] 
+  arr_lib.append(SConscript('SConscript_bsp_'+ Env['TARGET_BOARD'], exports='Env'))
+  arr_lib.append(SConscript('SConscript_psp', exports='Env'))
+  arr_lib.append(SConscript('SConscript_comrv_baremetal', exports='Env'))
+  Env['TARGET_LIBS'] += ['c', 'gcc']
 else:
-  print "missing example=[ex-freertos | TBD]"
+  print "missing example=[ex-freertos | ex-comrv_baremetal | TBD]"
   exit(1)
 
 arr_lib.append(SConscript('SConscript_example', exports='Env'))

--- a/WD-Firmware/examples/ex-comrv-baremetal/Licenses/Eclipse Public License - Version 1.0.html
+++ b/WD-Firmware/examples/ex-comrv-baremetal/Licenses/Eclipse Public License - Version 1.0.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!-- saved from url=(0046)https://eclipse.org/org/documents/epl-v10.html -->
+<html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<title>Eclipse Public License - Version 1.0</title>
+<style type="text/css">
+  body {
+    size: 8.5in 11.0in;
+    margin: 0.25in 0.5in 0.25in 0.5in;
+    tab-interval: 0.5in;
+    }
+  p {  	
+    margin-left: auto;
+    margin-top:  0.5em;
+    margin-bottom: 0.5em;
+    }
+  p.list {
+  	margin-left: 0.5in;
+    margin-top:  0.05em;
+    margin-bottom: 0.05em;
+    }
+  </style>
+
+</head>
+
+<body lang="EN-US">
+
+<h2>Eclipse Public License - v 1.0</h2>
+
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR
+DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
+AGREEMENT.</p>
+
+<p><b>1. DEFINITIONS</b></p>
+
+<p>"Contribution" means:</p>
+
+<p class="list">a) in the case of the initial Contributor, the initial
+code and documentation distributed under this Agreement, and</p>
+<p class="list">b) in the case of each subsequent Contributor:</p>
+<p class="list">i) changes to the Program, and</p>
+<p class="list">ii) additions to the Program;</p>
+<p class="list">where such changes and/or additions to the Program
+originate from and are distributed by that particular Contributor. A
+Contribution 'originates' from a Contributor if it was added to the
+Program by such Contributor itself or anyone acting on such
+Contributor's behalf. Contributions do not include additions to the
+Program which: (i) are separate modules of software distributed in
+conjunction with the Program under their own license agreement, and (ii)
+are not derivative works of the Program.</p>
+
+<p>"Contributor" means any person or entity that distributes
+the Program.</p>
+
+<p>"Licensed Patents" mean patent claims licensable by a
+Contributor which are necessarily infringed by the use or sale of its
+Contribution alone or when combined with the Program.</p>
+
+<p>"Program" means the Contributions distributed in accordance
+with this Agreement.</p>
+
+<p>"Recipient" means anyone who receives the Program under
+this Agreement, including all Contributors.</p>
+
+<p><b>2. GRANT OF RIGHTS</b></p>
+
+<p class="list">a) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free copyright license to reproduce, prepare derivative works
+of, publicly display, publicly perform, distribute and sublicense the
+Contribution of such Contributor, if any, and such derivative works, in
+source code and object code form.</p>
+
+<p class="list">b) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free patent license under Licensed Patents to make, use, sell,
+offer to sell, import and otherwise transfer the Contribution of such
+Contributor, if any, in source code and object code form. This patent
+license shall apply to the combination of the Contribution and the
+Program if, at the time the Contribution is added by the Contributor,
+such addition of the Contribution causes such combination to be covered
+by the Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per se is
+licensed hereunder.</p>
+
+<p class="list">c) Recipient understands that although each Contributor
+grants the licenses to its Contributions set forth herein, no assurances
+are provided by any Contributor that the Program does not infringe the
+patent or other intellectual property rights of any other entity. Each
+Contributor disclaims any liability to Recipient for claims brought by
+any other entity based on infringement of intellectual property rights
+or otherwise. As a condition to exercising the rights and licenses
+granted hereunder, each Recipient hereby assumes sole responsibility to
+secure any other intellectual property rights needed, if any. For
+example, if a third party patent license is required to allow Recipient
+to distribute the Program, it is Recipient's responsibility to acquire
+that license before distributing the Program.</p>
+
+<p class="list">d) Each Contributor represents that to its knowledge it
+has sufficient copyright rights in its Contribution, if any, to grant
+the copyright license set forth in this Agreement.</p>
+
+<p><b>3. REQUIREMENTS</b></p>
+
+<p>A Contributor may choose to distribute the Program in object code
+form under its own license agreement, provided that:</p>
+
+<p class="list">a) it complies with the terms and conditions of this
+Agreement; and</p>
+
+<p class="list">b) its license agreement:</p>
+
+<p class="list">i) effectively disclaims on behalf of all Contributors
+all warranties and conditions, express and implied, including warranties
+or conditions of title and non-infringement, and implied warranties or
+conditions of merchantability and fitness for a particular purpose;</p>
+
+<p class="list">ii) effectively excludes on behalf of all Contributors
+all liability for damages, including direct, indirect, special,
+incidental and consequential damages, such as lost profits;</p>
+
+<p class="list">iii) states that any provisions which differ from this
+Agreement are offered by that Contributor alone and not by any other
+party; and</p>
+
+<p class="list">iv) states that source code for the Program is available
+from such Contributor, and informs licensees how to obtain it in a
+reasonable manner on or through a medium customarily used for software
+exchange.</p>
+
+<p>When the Program is made available in source code form:</p>
+
+<p class="list">a) it must be made available under this Agreement; and</p>
+
+<p class="list">b) a copy of this Agreement must be included with each
+copy of the Program.</p>
+
+<p>Contributors may not remove or alter any copyright notices contained
+within the Program.</p>
+
+<p>Each Contributor must identify itself as the originator of its
+Contribution, if any, in a manner that reasonably allows subsequent
+Recipients to identify the originator of the Contribution.</p>
+
+<p><b>4. COMMERCIAL DISTRIBUTION</b></p>
+
+<p>Commercial distributors of software may accept certain
+responsibilities with respect to end users, business partners and the
+like. While this license is intended to facilitate the commercial use of
+the Program, the Contributor who includes the Program in a commercial
+product offering should do so in a manner which does not create
+potential liability for other Contributors. Therefore, if a Contributor
+includes the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and
+indemnify every other Contributor ("Indemnified Contributor")
+against any losses, damages and costs (collectively "Losses")
+arising from claims, lawsuits and other legal actions brought by a third
+party against the Indemnified Contributor to the extent caused by the
+acts or omissions of such Commercial Contributor in connection with its
+distribution of the Program in a commercial product offering. The
+obligations in this section do not apply to any claims or Losses
+relating to any actual or alleged intellectual property infringement. In
+order to qualify, an Indemnified Contributor must: a) promptly notify
+the Commercial Contributor in writing of such claim, and b) allow the
+Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own
+expense.</p>
+
+<p>For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.</p>
+
+<p><b>5. NO WARRANTY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION,
+ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
+OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and
+distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to
+the risks and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and unavailability or
+interruption of operations.</p>
+
+<p><b>6. DISCLAIMER OF LIABILITY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT
+NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+
+<p><b>7. GENERAL</b></p>
+
+<p>If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further action
+by the parties hereto, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.</p>
+
+<p>If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other
+software or hardware) infringes such Recipient's patent(s), then such
+Recipient's rights granted under Section 2(b) shall terminate as of the
+date such litigation is filed.</p>
+
+<p>All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of time
+after becoming aware of such noncompliance. If all Recipient's rights
+under this Agreement terminate, Recipient agrees to cease use and
+distribution of the Program as soon as reasonably practicable. However,
+Recipient's obligations under this Agreement and any licenses granted by
+Recipient relating to the Program shall continue and survive.</p>
+
+<p>Everyone is permitted to copy and distribute copies of this
+Agreement, but in order to avoid inconsistency the Agreement is
+copyrighted and may only be modified in the following manner. The
+Agreement Steward reserves the right to publish new versions (including
+revisions) of this Agreement from time to time. No one other than the
+Agreement Steward has the right to modify this Agreement. The Eclipse
+Foundation is the initial Agreement Steward. The Eclipse Foundation may
+assign the responsibility to serve as the Agreement Steward to a
+suitable separate entity. Each new version of the Agreement will be
+given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version
+of the Agreement is published, Contributor may elect to distribute the
+Program (including its Contributions) under the new version. Except as
+expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
+rights or licenses to the intellectual property of any Contributor under
+this Agreement, whether expressly, by implication, estoppel or
+otherwise. All rights in the Program not expressly granted under this
+Agreement are reserved.</p>
+
+<p>This Agreement is governed by the laws of the State of New York and
+the intellectual property laws of the United States of America. No party
+to this Agreement will bring a legal action under this Agreement more
+than one year after the cause of action arose. Each party waives its
+rights to a jury trial in any resulting litigation.</p>
+
+
+
+
+</body></html>

--- a/WD-Firmware/examples/ex-comrv-baremetal/Licenses/gpl-2.0.txt
+++ b/WD-Firmware/examples/ex-comrv-baremetal/Licenses/gpl-2.0.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/WD-Firmware/examples/ex-comrv-baremetal/Licenses/gpl-3.0.txt
+++ b/WD-Firmware/examples/ex-comrv-baremetal/Licenses/gpl-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/WD-Firmware/examples/ex-comrv-baremetal/main.c
+++ b/WD-Firmware/examples/ex-comrv-baremetal/main.c
@@ -1,0 +1,141 @@
+/* This file is based on led_blink code sample from FreedomStudio package
+ * (/FreedomStudio/SiFive/Examples/HiFive1/led_blink) */
+
+// See LICENSE for license details.
+
+// This is the program which ships on the HiFive1
+// board, executing out of SPI Flash at 0x20400000.
+
+#include <stdint.h>
+#include "platform.h"
+
+#ifndef _SIFIVE_HIFIVE1_H
+#error "'led_fade' is designed to run on HiFive1 and/or E300 Arty Dev Kit."
+#endif
+
+static const char led_msg[] = "\a\n\r\n\r\
+55555555555555555555555555555555555555555555555\n\r\
+5555555 Are the LEDs Changing? [y/n]  555555555\n\r\
+55555555555555555555555555555555555555555555555\n\r";
+
+
+static void _putc(char c) {
+  while ((int32_t) UART0_REG(UART_REG_TXFIFO) < 0);
+  UART0_REG(UART_REG_TXFIFO) = c;
+}
+
+int _getc(char * c){
+  int32_t val = (int32_t) UART0_REG(UART_REG_RXFIFO);
+  if (val > 0) {
+    *c =  val & 0xFF;
+    return 1;
+  }
+  return 0;
+}
+
+
+static void _puts(const char * s) {
+  while (*s != '\0'){
+    _putc(*s++);
+  }
+}
+
+int main (void){
+
+  // Make sure the HFROSC is on before the next line:
+  PRCI_REG(PRCI_HFROSCCFG) |= ROSC_EN(1);
+  // Run off 16 MHz Crystal for accuracy. Note that the
+  // first line is 
+  PRCI_REG(PRCI_PLLCFG) = (PLL_REFSEL(1) | PLL_BYPASS(1));
+  PRCI_REG(PRCI_PLLCFG) |= (PLL_SEL(1));
+  // Turn off HFROSC to save power
+  PRCI_REG(PRCI_HFROSCCFG) &= ~(ROSC_EN(1));
+  
+  // Configure UART to print
+  GPIO_REG(GPIO_OUTPUT_VAL) |= IOF0_UART0_MASK;
+  GPIO_REG(GPIO_OUTPUT_EN)  |= IOF0_UART0_MASK;
+  GPIO_REG(GPIO_IOF_SEL)    &= ~IOF0_UART0_MASK;
+  GPIO_REG(GPIO_IOF_EN)     |= IOF0_UART0_MASK;
+
+  // 115200 Baud Rate
+  UART0_REG(UART_REG_DIV) = 138;
+  UART0_REG(UART_REG_TXCTRL) = UART_TXEN;
+  UART0_REG(UART_REG_RXCTRL) = UART_RXEN;
+
+  // Wait a bit to avoid corruption on the UART.
+  // (In some cases, switching to the IOF can lead
+  // to output glitches, so need to let the UART
+  // reciever time out and resynchronize to the real 
+  // start of the stream.
+  volatile int i=0;
+  while(i < 10000){i++;}
+
+  //_puts(sifive_msg);
+  //_puts("Config String:\n\r");
+  //_puts(*((const char **) 0x100C));
+  //_puts("\n\r");
+  _puts(led_msg);
+  
+  uint16_t r=0xFF;
+  uint16_t g=0;
+  uint16_t b=0;
+  char c = 0;
+  
+  // Set up RGB PWM
+  
+  PWM1_REG(PWM_CFG)   = 0;
+  // To balance the power consumption, make one left, one right, and one center aligned.
+  PWM1_REG(PWM_CFG)   = (PWM_CFG_ENALWAYS) | (PWM_CFG_CMP2CENTER);
+  PWM1_REG(PWM_COUNT) = 0;
+  
+  // Period is approximately 244 Hz
+  // the LEDs are intentionally left somewhat dim, 
+  // as the full brightness can be painful to look at.
+  PWM1_REG(PWM_CMP0)  = 0;
+
+  GPIO_REG(GPIO_IOF_SEL)    |= ( (1 << GREEN_LED_OFFSET) | (1 << BLUE_LED_OFFSET) | (1 << RED_LED_OFFSET));
+  GPIO_REG(GPIO_IOF_EN )    |= ( (1 << GREEN_LED_OFFSET) | (1 << BLUE_LED_OFFSET) | (1 << RED_LED_OFFSET));
+  GPIO_REG(GPIO_OUTPUT_XOR) &= ~( (1 << GREEN_LED_OFFSET) | (1 << BLUE_LED_OFFSET));
+  GPIO_REG(GPIO_OUTPUT_XOR) |= (1 << RED_LED_OFFSET);
+
+  while(1){
+    volatile uint64_t *  now = (volatile uint64_t*)(CLINT_CTRL_ADDR + CLINT_MTIME);
+    volatile uint64_t then = *now + 100;
+    while (*now < then) { }
+  
+    if(r > 0 && b == 0){
+      r--;
+      g++;
+    }
+    if(g > 0 && r == 0){
+      g--;
+      b++;
+    }
+    if(b > 0 && g == 0){
+      r++;
+      b--;
+    }
+    
+    uint32_t G = g;
+    uint32_t R = r;
+    uint32_t B = b;
+    
+    PWM1_REG(PWM_CMP1)  = G << 4;            // PWM is low on the left, GPIO is low on the left side, LED is ON on the left.
+    PWM1_REG(PWM_CMP2)  = (B << 1) << 4;     // PWM is high on the middle, GPIO is low in the middle, LED is ON in the middle.
+    PWM1_REG(PWM_CMP3)  = 0xFFFF - (R << 4); // PWM is low on the left, GPIO is low on the right, LED is on on the right.
+  
+    // Check for user input
+    if (c == 0){
+      if (_getc(&c) != 0){
+        _putc(c);
+        _puts("\n\r");
+        
+        if ((c == 'y') || (c == 'Y')){
+          _puts("PASS\n\r");
+        } else{
+          _puts("FAIL\n\r");
+        }
+      }
+    }
+  }
+}

--- a/WD-Firmware/psp/api_inc/psp_api.h
+++ b/WD-Firmware/psp/api_inc/psp_api.h
@@ -27,11 +27,14 @@
 * include files
 */
 
+#include "psp_config.h"
+#include "psp_macro.h"
+#include "psp_defines.h"
+#include "psp_interrupt_api.h"
+
 /**
 * definitions
 */
-#define D_NON_INT_CONTEXT 0
-#define D_INT_CONTEXT     1
 
 /**
 * macros
@@ -56,16 +59,8 @@
 /**
 * APIs
 */
-
-
-/**
-* @brief check if in ISR context
-*
-* @param None
-*
-* @return u32_t            - D_NON_INT_CONTEXT
-*                          - non zero value - interrupt context
-*/
 u32_t pspIsInterruptContext(void);
+pspInterruptHandler_t pspRegisterIsrCauseHandler(pspInterruptHandler_t fptrRtosalInterruptHandler, pspInterruptCause_t eIntCause);
+pspInterruptHandler_t pspRegisterIsrExceptionHandler(pspInterruptHandler_t fptrRtosalInterruptHandler, pspExceptionCause_t eExcCause);
 
 #endif /* __PSP_API_H__ */

--- a/WD-Firmware/psp/api_inc/psp_asm_macros.h
+++ b/WD-Firmware/psp/api_inc/psp_asm_macros.h
@@ -1,0 +1,145 @@
+/*
+ SPDX-License-Identifier: Apache-2.0
+ Copyright 2019 Western Digital Corporation or its affiliates.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http:www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+.if __riscv_xlen == 64
+.macro m_STORE operand1,operand2
+    sd \operand1, \operand2
+.endm
+.macro m_LOAD operand1,operand2
+    ld \operand1, \operand2
+.endm
+.macro m_ADDI operand1,operand2,operand3
+    addiw \operand1, \operand2, \operand3
+.endm
+.equ REGBYTES, 8
+.else
+.macro m_STORE operand1,operand2
+    sw \operand1, \operand2
+.endm
+.macro m_LOAD operand1,operand2
+    lw \operand1, \operand2
+.endm
+.macro m_ADDI operand1,operand2,operand3
+    addi \operand1, \operand2, \operand3
+.endm
+.equ REGBYTES, 4
+.endif
+
+.macro m_SET_INT_CONTEXT
+    /* save address of g_uiIsInterruptContext -> t0 */
+    la        a0, g_uiIsInterruptContext
+    /* load the value g_uiIsInterruptContext -> t1 */
+    m_LOAD    a1, 0x0(a0)
+    /* increment t1 by 1 */
+    m_ADDI    a1, a1, 1
+    /* store new value to g_uiIsInterruptContext */
+    m_STORE   a1, 0x0(a0)
+.endm
+
+.macro m_CLEAR_INT_CONTEXT
+    /* save address of g_uiIsInterruptContext -> t0 */
+    la        a0, g_uiIsInterruptContext
+    /* load the value g_uiIsInterruptContext -> t1 */
+    m_LOAD    a1, 0x0(a0)
+    /* decrement t1 by 1 */
+    m_ADDI    a1, a1, -1
+    /* store new value to g_uiIsInterruptContext */
+    m_STORE   a1, 0x0(a0)
+.endm
+
+.macro m_CALL_INT_HANDLER fptIntHandler
+    /* load the address of provided fptIntHandler */
+    la        a0, \fptIntHandler
+    /* load the actual handler address */
+    m_LOAD    a0, 0x0(a0)
+    /* invoke the interrupt handler */
+    jalr      a0
+.endm
+
+/* Macro for saving task context */
+.macro m_pushREGFILE
+    /* make room in stack */
+    m_ADDI    sp, sp, -REGBYTES * 36
+    /* Save Context */
+    m_STORE   x1, 1 * REGBYTES(sp)
+    m_STORE   x2, 2 * REGBYTES(sp)
+    m_STORE   x4, 4 * REGBYTES(sp)
+    m_STORE   x5, 5 * REGBYTES(sp)
+    m_STORE   x6, 6 * REGBYTES(sp)
+    m_STORE   x7, 7 * REGBYTES(sp)
+    m_STORE   x8, 8 * REGBYTES(sp)
+    m_STORE   x9, 9 * REGBYTES(sp)
+    m_STORE   x10, 10 * REGBYTES(sp)
+    m_STORE   x11, 11 * REGBYTES(sp)
+    m_STORE   x12, 12 * REGBYTES(sp)
+    m_STORE   x13, 13 * REGBYTES(sp)
+    m_STORE   x14, 14 * REGBYTES(sp)
+    m_STORE   x15, 15 * REGBYTES(sp)
+    m_STORE   x16, 16 * REGBYTES(sp)
+    m_STORE   x17, 17 * REGBYTES(sp)
+    m_STORE   x18, 18 * REGBYTES(sp)
+    m_STORE   x19, 19 * REGBYTES(sp)
+    m_STORE   x20, 20 * REGBYTES(sp)
+    m_STORE   x21, 21 * REGBYTES(sp)
+    m_STORE   x22, 22 * REGBYTES(sp)
+    m_STORE   x23, 23 * REGBYTES(sp)
+    m_STORE   x24, 24 * REGBYTES(sp)
+    m_STORE   x25, 25 * REGBYTES(sp)
+    m_STORE   x26, 26 * REGBYTES(sp)
+    m_STORE   x27, 27 * REGBYTES(sp)
+    m_STORE   x28, 28 * REGBYTES(sp)
+    m_STORE   x29, 29 * REGBYTES(sp)
+    m_STORE   x30, 30 * REGBYTES(sp)
+    m_STORE   x31, 31 * REGBYTES(sp)
+.endm
+
+/* Macro for restoring task context */
+.macro m_popREGFILE
+    /* Restore registers,
+    Skip global pointer because that does not change */
+    m_LOAD    x1,   1 * REGBYTES(sp)
+    m_LOAD    x4,   4 * REGBYTES(sp)
+    m_LOAD    x5,   5 * REGBYTES(sp)
+    m_LOAD    x6,   6 * REGBYTES(sp)
+    m_LOAD    x7,   7 * REGBYTES(sp)
+    m_LOAD    x8,   8 * REGBYTES(sp)
+    m_LOAD    x9,   9 * REGBYTES(sp)
+    m_LOAD    x10, 10 * REGBYTES(sp)
+    m_LOAD    x11, 11 * REGBYTES(sp)
+    m_LOAD    x12, 12 * REGBYTES(sp)
+    m_LOAD    x13, 13 * REGBYTES(sp)
+    m_LOAD    x14, 14 * REGBYTES(sp)
+    m_LOAD    x15, 15 * REGBYTES(sp)
+    m_LOAD    x16, 16 * REGBYTES(sp)
+    m_LOAD    x17, 17 * REGBYTES(sp)
+    m_LOAD    x18, 18 * REGBYTES(sp)
+    m_LOAD    x19, 19 * REGBYTES(sp)
+    m_LOAD    x20, 20 * REGBYTES(sp)
+    m_LOAD    x21, 21 * REGBYTES(sp)
+    m_LOAD    x22, 22 * REGBYTES(sp)
+    m_LOAD    x23, 23 * REGBYTES(sp)
+    m_LOAD    x24, 24 * REGBYTES(sp)
+    m_LOAD    x25, 25 * REGBYTES(sp)
+    m_LOAD    x26, 26 * REGBYTES(sp)
+    m_LOAD    x27, 27 * REGBYTES(sp)
+    m_LOAD    x28, 28 * REGBYTES(sp)
+    m_LOAD    x29, 29 * REGBYTES(sp)
+    m_LOAD    x30, 30 * REGBYTES(sp)
+    m_LOAD    x31, 31 * REGBYTES(sp)
+    m_ADDI    sp, sp, REGBYTES * 36
+.endm
+

--- a/WD-Firmware/psp/api_inc/psp_config.h
+++ b/WD-Firmware/psp/api_inc/psp_config.h
@@ -15,56 +15,24 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   psp_config.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
-* 
+* @date   20.05.2019
+* @brief  The file defines the psp configuration
 */
+#ifndef  __PSP_CONFIG_H__
+#define  __PSP_CONFIG_H__
 
 /**
 * include files
 */
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
 
 /**
 * definitions
 */
 
-/**
-* macros
-*/
+/* TODO: change D_PSP_ERROR_CHECK to be determined by the build system */
+#define D_PSP_ERROR_CHECK            0
+#define D_PSP_NUM_OF_INTS_EXCEPTIONS E_EXC_LAST
 
-/**
-* types
-*/
-
-/**
-* local prototypes
-*/
-
-/**
-* external prototypes
-*/
-
-/**
-* global variables
-*/
-
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-
+#endif /* __PSP_CONFIG_H__ */

--- a/WD-Firmware/psp/api_inc/psp_defines.h
+++ b/WD-Firmware/psp/api_inc/psp_defines.h
@@ -15,56 +15,28 @@
 * limitations under the License.
 */
 /**
-* @file   rtosal_default.c
+* @file   psp_defines.h
 * @author Ronen Haen
-* @date   21.01.2019 
-* @brief  The file implements the RTOS AL default
+* @date   20.05.2019
+* @brief  The psp defines
 * 
 */
+#ifndef  __PSP_DEFINES_H__
+#define  __PSP_DEFINES_H__
 
 /**
 * include files
 */
-#include "rtosal_config.h"
-#include "rtosal_defines.h"
-#include "rtosal_types.h"
-#include "rtosal_macro.h"
 
 /**
 * definitions
 */
+/* interrupt context indication values */
+#define D_PSP_NON_INT_CONTEXT              0
+#define D_PSP_INT_CONTEXT                  1
 
-/**
-* macros
-*/
-
-/**
-* types
-*/
-
-/**
-* local prototypes
-*/
-
-/**
-* external prototypes
-*/
-
-/**
-* global variables
-*/
-
-/**
-* default 'param error' notification function
-*
-* @param pParam      pointer of the invalid parameter
-* @param uiErrorCode  error code
-*
-* @return none
-*/
-RTOSAL_SECTION void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode)
-{
-   (void)pParam;
-   (void)uiErrorCode;
-}
-
+/* function return codes */
+#define D_PSP_SUCCESS                      0x00
+#define D_PSP_FAIL                          0x01
+#define D_PSP_PTR_ERROR                    0x02
+#endif /* __PSP_DEFINES_H__ */

--- a/WD-Firmware/psp/api_inc/psp_interrupt_api.h
+++ b/WD-Firmware/psp/api_inc/psp_interrupt_api.h
@@ -1,0 +1,109 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+* Copyright 2019 Western Digital Corporation or its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http:*www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/**
+* @file   psp_interrupt_api.h
+* @author Ronen Haen
+* @date   20.05.2019
+* @brief  The file defines the psp interrupt interfaces
+*/
+#ifndef __PSP_INTERRUPT_API_H__
+#define __PSP_INTERRUPT_API_H__
+
+/**
+* include files
+*/
+
+/**
+* definitions
+*/
+
+/**
+* macros
+*/
+
+/**
+* types
+*/
+
+/* */
+typedef enum pspInterruptCause
+{
+   E_USER_SOFTWARE_CAUSE       = 0,
+   E_SUPERVISOR_SOFTWARE_CAUSE = 1,
+   E_RESERVED_SOFTWARE_CAUSE   = 2,
+   E_MACHINE_SOFTWARE_CAUSE    = 3,
+   E_USER_TIMER_CAUSE          = 4,
+   E_SUPERVISOR_TIMER_CAUSE    = 5,
+   E_RESERVED_TIMER_CAUSE      = 6,
+   E_MACHINE_TIMER_CAUSE       = 7,
+   E_USER_EXTERNAL_CAUSE       = 8,
+   E_SUPERVISOR_EXTERNAL_CAUSE = 9,
+   E_RESERVED_EXTERNAL_CAUSE   = 10,
+   E_MACHINE_EXTERNAL_CAUSE    = 11,
+   E_LAST_CAUSE
+} pspInterruptCause_t;
+
+/* Exceptions */
+typedef enum pspExceptionCause
+{
+   E_EXC_INSTRUCTION_ADDRESS_MISALIGNED           = 0,
+   E_EXC_INSTRUCTION_ACCESS_FAULT                 = 1,
+   E_EXC_ILLEGAL_INSTRUCTION                      = 2,
+   E_EXC_BREAKPOINT                               = 3,
+   E_EXC_LOAE_EXC_ADDRESS_MISALIGNED              = 4,
+   E_EXC_LOAE_EXC_ACCESS_FAULT                    = 5,
+   E_EXC_STORE_AMO_ADDRESS_MISALIGNED             = 6,
+   E_EXC_STORE_AMO_ACCESS_FAULT                   = 7,
+   E_EXC_ENVIRONMENT_CALL_FROM_UMODE              = 8,
+   E_EXC_ENVIRONMENT_CALL_FROM_SMODE              = 9,
+   E_EXC_RESERVED                                 = 10,
+   E_EXC_ENVIRONMENT_CALL_FROM_MMODE              = 11,
+   E_EXC_INSTRUCTION_PAGE_FAULT                   = 12,
+   E_EXC_LOAE_EXC_PAGE_FAULT                      = 13,
+   E_EXC_RESERVEE_EXC_FOR_FUTURE_STANDARE_EXC_USE = 14,
+   E_EXC_STORE_AMO_PAGE_FAULT                     = 15,
+   E_EXC_LAST
+} pspExceptionCause_t;
+
+typedef enum pspExternIntHandlerPrivilege
+{
+   E_EXT_USER_INT_HNDLR       = E_USER_EXTERNAL_CAUSE,
+   E_EXT_SUPERVISOR_INT_HNDLR = E_SUPERVISOR_EXTERNAL_CAUSE,
+   E_EXT_MACHINE_INT_HNDLR    = E_MACHINE_EXTERNAL_CAUSE,
+   E_EXT_INT_HNDLR_LAST
+} pspExternIntHandlerPrivilege_t;
+
+/* interrupt handler definition */
+typedef void (*pspInterruptHandler_t)(void);
+
+/**
+* local prototypes
+*/
+
+/**
+* external prototypes
+*/
+
+/**
+* global variables
+*/
+
+/**
+* APIs
+*/
+
+#endif /* __PSP_INTERRUPT_API_H__ */

--- a/WD-Firmware/psp/api_inc/psp_macro.h
+++ b/WD-Firmware/psp/api_inc/psp_macro.h
@@ -1,0 +1,67 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+* Copyright 2019 Western Digital Corporation or its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http:*www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/**
+* @file   psp_macro.h
+* @author Ronen Haen
+* @date   20.05.2019
+* @brief  The file defines the psp macros
+*/
+#ifndef __PSP_MACRO_H__
+#define __PSP_MACRO_H__
+
+/**
+* include files
+*/
+
+/**
+* macros
+*/
+/* error checking macro */
+#if (D_PSP_ERROR_CHECK==1)
+   /* TODO: need to add default function */
+   #define M_PSP_VALIDATE_FUNC_PARAM(param, conditionMet, returnCode) \
+      if (conditionMet) \
+      { \
+         fptrParamErrorNotification((const void*)(param), returnCode); \
+         return (returnCode); \
+      }
+#else
+   #define M_PSP_VALIDATE_FUNC_PARAM(param, conditionMet, returnCode)
+#endif /* #if (D_PSP_ERROR_CHECK==1) */
+
+#if (D_PSP_ASSERT==1)
+   #define M_PSP_ASSERT(checkedResult)
+   /* TODO add assert call */
+#else
+   #define M_PSP_ASSERT(checkedResult)
+#endif /* #if (D_PSP_ASSERT==1)  */
+
+
+#define PSP_TEXT_SECTION __attribute__((section("PSP_TEXT_SEC")))
+#define PSP_DATA_SECTION __attribute__((section("PSP_DATA_SEC")))
+
+#define M_PSP_READ_CSR(reg) (	{ unsigned long __tmp; \
+  asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
+  __tmp; })
+
+#define M_PSP_WRITE_CSR(reg, val) ({ \
+  if (__builtin_constant_p(val) && (unsigned long)(val) < 32) \
+    asm volatile ("csrw " #reg ", %0" :: "i"(val)); \
+  else \
+    asm volatile ("csrw " #reg ", %0" :: "r"(val)); })
+
+#endif /* __PSP_MACRO_H__ */

--- a/WD-Firmware/psp/psp_int_vect.S
+++ b/WD-Firmware/psp/psp_int_vect.S
@@ -1,0 +1,172 @@
+/*
+    FreeRTOS V8.2.3 - Copyright (C) 2015 Real Time Engineers Ltd.
+    All rights reserved
+
+    VISIT http://www.FreeRTOS.org TO ENSURE YOU ARE USING THE LATEST VERSION.
+
+    This file is part of the FreeRTOS distribution and was contributed
+    to the project by Technolution B.V. (www.technolution.nl,
+    freertos-riscv@technolution.eu) under the terms of the FreeRTOS
+    contributors license.
+
+    FreeRTOS is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License (version 2) as published by the
+    Free Software Foundation >>>> AND MODIFIED BY <<<< the FreeRTOS exception.
+
+    ***************************************************************************
+    >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+    >>!   distribute a combined work that includes FreeRTOS without being   !<<
+    >>!   obliged to provide the source code for proprietary components     !<<
+    >>!   outside of the FreeRTOS kernel.                                   !<<
+    ***************************************************************************
+
+    FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+    link: http://www.freertos.org/a00114.html
+
+    ***************************************************************************
+     *                                                                       *
+     *    FreeRTOS provides completely free yet professionally developed,    *
+     *    robust, strictly quality controlled, supported, and cross          *
+     *    platform software that is more than just the market leader, it     *
+     *    is the industry''s de facto standard.                               *
+     *                                                                       *
+     *    Help yourself get started quickly while simultaneously helping     *
+     *    to support the FreeRTOS project by purchasing a FreeRTOS           *
+     *    tutorial book, reference manual, or both:                          *
+     *    http://www.FreeRTOS.org/Documentation                              *
+     *                                                                       *
+    ***************************************************************************
+
+    http://www.FreeRTOS.org/FAQHelp.html - Having a problem?  Start by reading
+    the FAQ page "My application does not run, what could be wrong?".  Have you
+    defined configASSERT()?
+
+    http://www.FreeRTOS.org/support - In return for receiving this top quality
+    embedded software for free we request you assist our global community by
+    participating in the support forum.
+
+    http://www.FreeRTOS.org/training - Investing in training allows your team to
+    be as productive as possible as early as possible.  Now you can receive
+    FreeRTOS training directly from Richard Barry, CEO of Real Time Engineers
+    Ltd, and the world's leading authority on the world's leading RTOS.
+
+    http://www.FreeRTOS.org/plus - A selection of FreeRTOS ecosystem products,
+    including FreeRTOS+Trace - an indispensable productivity tool, a DOS
+    compatible FAT file system, and our tiny thread aware UDP/IP stack.
+
+    http://www.FreeRTOS.org/labs - Where new FreeRTOS products go to incubate.
+    Come and try FreeRTOS+TCP, our new open source TCP/IP stack for FreeRTOS.
+
+    http://www.OpenRTOS.com - Real Time Engineers ltd. license FreeRTOS to High
+    Integrity Systems ltd. to sell under the OpenRTOS brand.  Low cost OpenRTOS
+    licenses offer ticketed support, indemnification and commercial middleware.
+
+    http://www.SafeRTOS.com - High Integrity Systems also provide a safety
+    engineered and independently SIL3 certified version for use in safety and
+    mission critical applications that require provable dependability.
+
+    1 tab == 4 spaces!
+*/
+
+/*
+This implementation supports riscv privileged v1.10
+*/
+
+.include "psp_asm_macros.h"
+
+.section  .text.entry
+.align 4
+.global   psp_vect_table
+
+.ifndef D_PSP_VECT_TABLE
+psp_vect_table:
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+    csrr    t0, mcause
+    bge	    t0, zero, psp_vect_table_
+    slli    t0, t0, 2
+    la      t1, psp_vect_table_
+    add     t0, t0, t1
+    jr      t0
+.endif /* D_PSP_VECT_TABLE */
+
+.align 4
+.ifndef D_PSP_VECT_TABLE
+psp_vect_table_:
+.else
+psp_vect_table:
+.endif
+    j psp_exceptions_int       /* User software interrupt & exceptions */
+    .align 2
+    j psp_reserved_int         /* Supervisor software interrupt    */
+    .align 2
+    j psp_reserved_int         /* Reserved for future standard use */
+    .align 2
+    j psp_m_soft_int           /* Machine software interrupt       */
+    .align 2
+    j psp_reserved_int         /* User timer interrupt             */
+    .align 2
+    j psp_reserved_int         /* Supervisor timer interrupt       */
+    .align 2
+    j psp_reserved_int         /* Reserved for future standard use */
+    .align 2
+    j psp_m_timer_int          /* Machine timer interrupt          */
+    .align 2
+    j psp_reserved_int         /* User external interrupt          */
+    .align 2
+    j psp_reserved_int         /* Supervisor external interrupt    */
+    .align 2
+    j psp_reserved_int         /* Reserved for future standard use */
+    .align 2
+    j psp_m_external_int       /* Machine external interrupt       */
+    .align 2
+
+psp_exceptions_int:
+.ifdef D_PSP_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_PSP_VECT_TABLE */
+    /* call the exception handler */
+    m_CALL_INT_HANDLER g_fptrIntExceptionIntHandler
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+psp_m_soft_int:
+.ifdef D_PSP_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_PSP_VECT_TABLE */
+    m_CALL_INT_HANDLER g_fptrIntMSoftIntHandler
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+psp_m_timer_int:
+.ifdef D_PSP_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_PSP_VECT_TABLE */
+    m_CALL_INT_HANDLER g_fptrIntMTimerIntHandler
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+psp_m_external_int:
+.ifdef D_PSP_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_PSP_VECT_TABLE */
+    m_CALL_INT_HANDLER g_fptrIntMExternIntHandler
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+.weak psp_reserved_int
+psp_reserved_int:
+1:
+    nop
+    nop
+    j 1b

--- a/WD-Firmware/psp/psp_interrupt.c
+++ b/WD-Firmware/psp/psp_interrupt.c
@@ -1,0 +1,262 @@
+/* 
+* SPDX-License-Identifier: Apache-2.0
+* Copyright 2019 Western Digital Corporation or its affiliates.
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+* http:*www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/**
+* @file   psp_interrupt.c
+* @author Ronen Haen
+* @date   20.05.2019
+* @brief  The file implements the PSP interrupt API
+* 
+*/
+
+/**
+* include files
+*/
+#include "common_types.h"
+#include "psp_api.h"
+#include "psp_interrupt_api.h"
+
+/**
+* definitions
+*/
+
+/**
+* macros
+*/
+
+/**
+* types
+*/
+u32_t g_uiIsInterruptContext = D_PSP_NON_INT_CONTEXT;
+
+/**
+* local prototypes
+*/
+void pspDefaultExceptionIntHandler_isr(void);
+void pspDefaultMSoftIntHandler_isr(void);
+void pspDefaultMTimerIntHandler_isr(void);
+void pspDefaultMExternIntHandler_isr(void);
+void pspDefaultEmptyIntHandler_isr(void);
+
+/**
+* external prototypes
+*/
+
+/**
+* global variables
+*/
+
+PSP_DATA_SECTION pspInterruptHandler_t  gExceptions_ints[D_PSP_NUM_OF_INTS_EXCEPTIONS] = {
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr,
+                                    pspDefaultEmptyIntHandler_isr };
+
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntExceptionIntHandler   = pspDefaultExceptionIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntSSoftIntHandler       = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntRsrvdSoftIntHandler   = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntMSoftIntHandler       = pspDefaultMSoftIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntUTimerIntHandler      = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntSTimerIntHandler      = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntRsrvdTimerIntHandler  = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntMTimerIntHandler      = pspDefaultMTimerIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntUExternIntHandler     = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntSExternIntHandler     = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntRsrvdExternIntHandler = pspDefaultEmptyIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntMExternIntHandler     = pspDefaultMExternIntHandler_isr;
+PSP_DATA_SECTION pspInterruptHandler_t g_fptrIntUSoftIntHandler       = pspDefaultEmptyIntHandler_isr;
+
+/**
+* The function installs an interrupt service routine per risc-v cause
+*
+* @param fptrInterruptHandler     – function pointer to the interrupt service routine
+* @param eIntCause                – interrupt source
+*
+* @return u32_t                   - previously registered ISR
+*/
+PSP_TEXT_SECTION pspInterruptHandler_t pspRegisterIsrCauseHandler(pspInterruptHandler_t fptrInterruptHandler,
+		                                     pspInterruptCause_t eIntCause)
+{
+   pspInterruptHandler_t pFptr;
+
+   M_PSP_ASSERT(fptrInterruptHandler == NULL && eIntCause >= E_LAST_CAUSE);
+
+   switch (eIntCause)
+   {
+      case E_USER_SOFTWARE_CAUSE:
+    	  pFptr = g_fptrIntUSoftIntHandler;
+    	  g_fptrIntUSoftIntHandler = fptrInterruptHandler;
+    	  break;
+      case E_SUPERVISOR_SOFTWARE_CAUSE:
+    	  pFptr = g_fptrIntSSoftIntHandler;
+    	  g_fptrIntSSoftIntHandler = fptrInterruptHandler;
+          break;
+      case E_RESERVED_SOFTWARE_CAUSE:
+    	  pFptr = g_fptrIntRsrvdSoftIntHandler;
+    	  g_fptrIntRsrvdSoftIntHandler = fptrInterruptHandler;
+    	  break;
+      case E_MACHINE_SOFTWARE_CAUSE:
+    	  pFptr = g_fptrIntMSoftIntHandler;
+    	  g_fptrIntMSoftIntHandler = fptrInterruptHandler;
+          break;
+      case E_USER_TIMER_CAUSE:
+    	  pFptr = g_fptrIntUTimerIntHandler;
+    	  g_fptrIntUTimerIntHandler = fptrInterruptHandler;
+    	  break;
+      case E_SUPERVISOR_TIMER_CAUSE:
+    	  pFptr = g_fptrIntSTimerIntHandler;
+    	  g_fptrIntSTimerIntHandler = fptrInterruptHandler;
+    	  break;
+      case E_RESERVED_TIMER_CAUSE:
+    	  pFptr = g_fptrIntRsrvdTimerIntHandler;
+    	  g_fptrIntRsrvdTimerIntHandler = fptrInterruptHandler;
+    	  break;
+      case E_MACHINE_TIMER_CAUSE:
+    	  pFptr = g_fptrIntMTimerIntHandler;
+    	  g_fptrIntMTimerIntHandler = fptrInterruptHandler;
+    	  break;
+      case E_USER_EXTERNAL_CAUSE:
+    	  pFptr = g_fptrIntUExternIntHandler;
+    	  g_fptrIntUExternIntHandler = fptrInterruptHandler;
+          break;
+      case E_SUPERVISOR_EXTERNAL_CAUSE:
+    	  pFptr = g_fptrIntSExternIntHandler;
+    	  g_fptrIntSExternIntHandler = fptrInterruptHandler;
+          break;
+      case E_RESERVED_EXTERNAL_CAUSE:
+    	  pFptr = g_fptrIntRsrvdExternIntHandler;
+    	  g_fptrIntRsrvdExternIntHandler = fptrInterruptHandler;
+    	  break;
+      case E_MACHINE_EXTERNAL_CAUSE:
+    	  pFptr = g_fptrIntMExternIntHandler;
+    	  g_fptrIntMExternIntHandler = fptrInterruptHandler;
+    	  break;
+      default:
+    	  pFptr = NULL;
+    	  break;
+   }
+
+   return pFptr;
+}
+
+/**
+* The function installs an exception handler per exception cause
+*
+* @param fptrInterruptHandler     – function pointer to the exception handler
+* @param eExcCause                – exception cause
+*
+* @return u32_t                   - previously registered ISR
+*/
+PSP_TEXT_SECTION pspInterruptHandler_t pspRegisterIsrExceptionHandler(pspInterruptHandler_t fptrInterruptHandler,
+		                                         pspExceptionCause_t eExcCause)
+{
+   pspInterruptHandler_t pFptr;
+
+   M_PSP_ASSERT(fptrInterruptHandler == NULL && eExcCause >= E_EXC_LAST);
+
+   pFptr = gExceptions_ints[eExcCause];
+
+   gExceptions_ints[eExcCause] = fptrInterruptHandler;
+
+   return pFptr;
+}
+
+/**
+* default exception interrupt handler
+*
+* @param none
+*
+* @return none
+*/
+PSP_TEXT_SECTION void pspDefaultExceptionIntHandler_isr(void)
+{
+   /* get the exception cause */
+   u32_t cause = M_PSP_READ_CSR(mcause);
+
+   /* is it a valid cause */
+   M_PSP_ASSERT(cause < D_PSP_NUM_OF_INTS_EXCEPTIONS);
+
+   /* call the specific exception handler */
+   gExceptions_ints[cause]();
+}
+
+/**
+* default machine software interrupt handler
+*
+* @param none
+*
+* @return none
+*/
+PSP_TEXT_SECTION void pspDefaultMSoftIntHandler_isr(void)
+{
+}
+
+/**
+* default machine timer interrupt handler
+*
+* @param none
+*
+* @return none
+*/
+PSP_TEXT_SECTION void pspDefaultMTimerIntHandler_isr(void)
+{
+}
+
+/**
+* default machine external interrupt handler
+*
+* @param none
+*
+* @return none
+*/
+PSP_TEXT_SECTION void pspDefaultMExternIntHandler_isr(void)
+{
+}
+
+/**
+* default empty interrupt handler
+*
+* @param none
+*
+* @return none
+*/
+PSP_TEXT_SECTION void pspDefaultEmptyIntHandler_isr(void)
+{
+}
+
+/**
+* @brief check if in ISR context
+*
+* @param None
+*
+* @return u32_t            - D_NON_INT_CONTEXT
+*                          - non zero value - interrupt context
+*/
+u32_t pspIsInterruptContext(void)
+{
+   return (g_uiIsInterruptContext > 0);
+}

--- a/WD-Firmware/rtos/rtos_core/freertos/Source/portable/GCC/RISCV/port.c
+++ b/WD-Firmware/rtos/rtos_core/freertos/Source/portable/GCC/RISCV/port.c
@@ -105,10 +105,10 @@ static void prvTaskExitError( void );
 
 
 /*-----------------------------------------------------------*/
-
 /* System Call Trap */
 //ECALL macro stores argument in a2
-unsigned long ulSynchTrap(unsigned long mcause, unsigned long sp, unsigned long arg1)	{
+unsigned long ulSynchTrap(unsigned long mcause, unsigned long sp, unsigned long arg1)
+{
 
 	switch(mcause)	{
 		//on User and Machine ECALL, handler the request
@@ -145,6 +145,16 @@ unsigned long ulSynchTrap(unsigned long mcause, unsigned long sp, unsigned long 
 	return sp;
 }
 
+void vSynchTrap(void)
+{
+	vPortYield();
+}
+
+void vSynchTrapUnhandled(void)
+{
+	write(1, "trap\n", 5);
+	_exit(read_csr(mcause));
+}
 
 void vPortEnterCritical( void )
 {
@@ -257,7 +267,7 @@ void vPortSysTickHandler(){
 	*mtimecmp = then;
 
    /* Increment the RTOS tick. */
-#if 0
+#ifndef D_USE_RTOSAL
 	if( xTaskIncrementTick() != pdFALSE )
 	{
 		vTaskSwitchContext();

--- a/WD-Firmware/rtos/rtos_core/freertos/Source/portable/GCC/RISCV/portasm.S
+++ b/WD-Firmware/rtos/rtos_core/freertos/Source/portable/GCC/RISCV/portasm.S
@@ -99,223 +99,171 @@
 .global vPortEndScheduler
 .global xExitStack
 .global trap_entry
-.global g_uiIsInterruptContext
+.global vPortYieldFromInterrupt
 
 .macro SET_INT_CONTEXT
-	/* save address of g_uiIsInterruptContext -> t0 */
-	la   	t0, g_uiIsInterruptContext
-	/* load the value g_uiIsInterruptContext -> t1 */
-	LOAD	t1, 0x0(t0)
-	/* increment t1 by 1 */
-	ADDI    t1, t1, 1
-	/* store new value to g_uiIsInterruptContext */
-	STORE	t1, 0x0(t0)
+    /* save address of g_uiIsInterruptContext -> t0 */
+    la       t0, g_uiIsInterruptContext
+    /* load the value g_uiIsInterruptContext -> t1 */
+    LOAD    t1, 0x0(t0)
+    /* increment t1 by 1 */
+    ADDI    t1, t1, 1
+    /* store new value to g_uiIsInterruptContext */
+    STORE    t1, 0x0(t0)
 .endm
 
 .macro CLEAR_INT_CONTEXT
-	/* save address of g_uiIsInterruptContext -> t0 */
-	la      t0, g_uiIsInterruptContext
-	/* load the value g_uiIsInterruptContext -> t1 */
-	LOAD	t1, 0x0(t0)
-	/* decrement t1 by 1 */
-	ADDI    t1, t1, -1
-	/* store new value to g_uiIsInterruptContext */
-	STORE	t1, 0x0(t0)
+    /* save address of g_uiIsInterruptContext -> t0 */
+    la      t0, g_uiIsInterruptContext
+    /* load the value g_uiIsInterruptContext -> t1 */
+    LOAD    t1, 0x0(t0)
+    /* decrement t1 by 1 */
+    ADDI    t1, t1, -1
+    /* store new value to g_uiIsInterruptContext */
+    STORE    t1, 0x0(t0)
 .endm
 
 /* Macro for saving task context */
 .macro pushREGFILE
-	/* make room in stack */
-	addi	sp, sp, -REGBYTES * 34
+    /* make room in stack */
+    addi    sp, sp, -REGBYTES * 36
 
-	/* Save Context */
-	STORE	x1, 1 * REGBYTES(sp)
-	STORE	x2, 2 * REGBYTES(sp)
-	//STORE	x3, 3 * REGBYTES(sp)
-	STORE	x4, 4 * REGBYTES(sp)
-	STORE	x5, 5 * REGBYTES(sp)
-	STORE	x6, 6 * REGBYTES(sp)
-	STORE	x7, 7 * REGBYTES(sp)
-	STORE	x8, 8 * REGBYTES(sp)
-	STORE	x9, 9 * REGBYTES(sp)
-	STORE	x10, 10 * REGBYTES(sp)
-	STORE	x11, 11 * REGBYTES(sp)
-	STORE	x12, 12 * REGBYTES(sp)
-	STORE	x13, 13 * REGBYTES(sp)
-	STORE	x14, 14 * REGBYTES(sp)
-	STORE	x15, 15 * REGBYTES(sp)
-	STORE	x16, 16 * REGBYTES(sp)
-	STORE	x17, 17 * REGBYTES(sp)
-	STORE	x18, 18 * REGBYTES(sp)
-	STORE	x19, 19 * REGBYTES(sp)
-	STORE	x20, 20 * REGBYTES(sp)
-	STORE	x21, 21 * REGBYTES(sp)
-	STORE	x22, 22 * REGBYTES(sp)
-	STORE	x23, 23 * REGBYTES(sp)
-	STORE	x24, 24 * REGBYTES(sp)
-	STORE	x25, 25 * REGBYTES(sp)
-	STORE	x26, 26 * REGBYTES(sp)
-	STORE	x27, 27 * REGBYTES(sp)
-	STORE	x28, 28 * REGBYTES(sp)
-	STORE	x29, 29 * REGBYTES(sp)
-	STORE	x30, 30 * REGBYTES(sp)
-	STORE	x31, 31 * REGBYTES(sp)
-	
+    /* Save Context */
+    STORE    x1, 1 * REGBYTES(sp)
+    STORE    x2, 2 * REGBYTES(sp)
+    STORE    x4, 4 * REGBYTES(sp)
+    STORE    x5, 5 * REGBYTES(sp)
+    STORE    x6, 6 * REGBYTES(sp)
+    STORE    x7, 7 * REGBYTES(sp)
+    STORE    x8, 8 * REGBYTES(sp)
+    STORE    x9, 9 * REGBYTES(sp)
+    STORE    x10, 10 * REGBYTES(sp)
+    STORE    x11, 11 * REGBYTES(sp)
+    STORE    x12, 12 * REGBYTES(sp)
+    STORE    x13, 13 * REGBYTES(sp)
+    STORE    x14, 14 * REGBYTES(sp)
+    STORE    x15, 15 * REGBYTES(sp)
+    STORE    x16, 16 * REGBYTES(sp)
+    STORE    x17, 17 * REGBYTES(sp)
+    STORE    x18, 18 * REGBYTES(sp)
+    STORE    x19, 19 * REGBYTES(sp)
+    STORE    x20, 20 * REGBYTES(sp)
+    STORE    x21, 21 * REGBYTES(sp)
+    STORE    x22, 22 * REGBYTES(sp)
+    STORE    x23, 23 * REGBYTES(sp)
+    STORE    x24, 24 * REGBYTES(sp)
+    STORE    x25, 25 * REGBYTES(sp)
+    STORE    x26, 26 * REGBYTES(sp)
+    STORE    x27, 27 * REGBYTES(sp)
+    STORE    x28, 28 * REGBYTES(sp)
+    STORE    x29, 29 * REGBYTES(sp)
+    STORE    x30, 30 * REGBYTES(sp)
+    STORE    x31, 31 * REGBYTES(sp)
+
 .endm
 
-/*saves mstatus and tcb	*/
+/*saves mstatus and tcb    */
 .macro portSAVE_CONTEXT
-	.global	pxCurrentTCB
-		/* Store mstatus */
-	csrr	t0, mstatus	//pointer
-	STORE	t0, 32 * REGBYTES(sp)
+    .global    pxCurrentTCB
+    /* Store mstatus */
+    csrr    t0, mstatus    //pointer
+    STORE    t0, 32 * REGBYTES(sp)
 
-	/* Store current stackpointer in task control block (TCB) */
-	LOAD	t0, pxCurrentTCB	//pointer
-	STORE	sp, 0x0(t0)
+    /* Store current stackpointer in task control block (TCB) */
+    LOAD    t0, pxCurrentTCB    //pointer
+    STORE    sp, 0x0(t0)
 .endm
 
 
 /* Saves current error program counter (EPC) as task program counter */
 .macro portSAVE_EPC
-  	csrr	t0, mepc
-	STORE	t0, 33 * REGBYTES(sp)
-
+    csrr    t0, mepc
+    STORE    t0, 33 * REGBYTES(sp)
 .endm
 
 /* Saves current return adress (RA) as task program counter */
 .macro portSAVE_RA
-	LOAD	t0, 1 * REGBYTES(sp)
-	STORE	t0, 33 * REGBYTES(sp)
-
+    LOAD    t0, 1 * REGBYTES(sp)
+    STORE    t0, 33 * REGBYTES(sp)
 .endm
 
 //not called on a context switch
 .macro portRESTORE_X2
-	LOAD 	x2, 2 * REGBYTES(sp)
-	//LOAD 	x3, 3 * REGBYTES(sp)
+    LOAD     x2, 2 * REGBYTES(sp)
+    //LOAD     x3, 3 * REGBYTES(sp)
  .endm
 
- /*restore mstatus and tcb	*/
+ /*restore mstatus and tcb    */
 .macro portRESTORE_CONTEXT
-	.global	pxCurrentTCB
-	/* Load stack pointer from the current TCB */
-	LOAD	sp, pxCurrentTCB
-	LOAD	sp, 0x0(sp)
-	/* Load task program counter */
-	LOAD	t0, 33 * REGBYTES(sp)
-  	csrw	mepc, t0
-	/* Load saved mstatus */
-	LOAD	t0, 32 * REGBYTES(sp)
-  	csrw	mstatus, t0
+    .global    pxCurrentTCB
+    /* Load stack pointer from the current TCB */
+    LOAD    sp, pxCurrentTCB
+    LOAD    sp, 0x0(sp)
+    /* Load task program counter */
+    LOAD    t0, 33 * REGBYTES(sp)
+    csrw    mepc, t0
+    /* Load saved mstatus */
+    LOAD    t0, 32 * REGBYTES(sp)
+    csrw    mstatus, t0
 .endm
 
 
 /* Macro for restoring task context */
 .macro popREGFILE
+    /* Restore registers, Skip global pointer because that does not change */
+    LOAD    x1, 1 * REGBYTES(sp)
+    LOAD    x4, 4 * REGBYTES(sp)
+    LOAD    x5, 5 * REGBYTES(sp)
+    LOAD    x6, 6 * REGBYTES(sp)
+    LOAD    x7, 7 * REGBYTES(sp)
+    LOAD    x8, 8 * REGBYTES(sp)
+    LOAD    x9, 9 * REGBYTES(sp)
+    LOAD    x10, 10 * REGBYTES(sp)
+    LOAD    x11, 11 * REGBYTES(sp)
+    LOAD    x12, 12 * REGBYTES(sp)
+    LOAD    x13, 13 * REGBYTES(sp)
+    LOAD    x14, 14 * REGBYTES(sp)
+    LOAD    x15, 15 * REGBYTES(sp)
+    LOAD    x16, 16 * REGBYTES(sp)
+    LOAD    x17, 17 * REGBYTES(sp)
+    LOAD    x18, 18 * REGBYTES(sp)
+    LOAD    x19, 19 * REGBYTES(sp)
+    LOAD    x20, 20 * REGBYTES(sp)
+    LOAD    x21, 21 * REGBYTES(sp)
+    LOAD    x22, 22 * REGBYTES(sp)
+    LOAD    x23, 23 * REGBYTES(sp)
+    LOAD    x24, 24 * REGBYTES(sp)
+    LOAD    x25, 25 * REGBYTES(sp)
+    LOAD    x26, 26 * REGBYTES(sp)
+    LOAD    x27, 27 * REGBYTES(sp)
+    LOAD    x28, 28 * REGBYTES(sp)
+    LOAD    x29, 29 * REGBYTES(sp)
+    LOAD    x30, 30 * REGBYTES(sp)
+    LOAD    x31, 31 * REGBYTES(sp)
 
-	/* Restore registers,
-	Skip global pointer because that does not change */
-	LOAD	x1, 1 * REGBYTES(sp)
-	//LOAD 	x3, 3 * REGBYTES(sp)
-	LOAD	x4, 4 * REGBYTES(sp)
-	LOAD	x5, 5 * REGBYTES(sp)
-	LOAD	x6, 6 * REGBYTES(sp)
-	LOAD	x7, 7 * REGBYTES(sp)
-	LOAD	x8, 8 * REGBYTES(sp)
-	LOAD	x9, 9 * REGBYTES(sp)
-	LOAD	x10, 10 * REGBYTES(sp)
-	LOAD	x11, 11 * REGBYTES(sp)
-	LOAD	x12, 12 * REGBYTES(sp)
-	LOAD	x13, 13 * REGBYTES(sp)
-	LOAD	x14, 14 * REGBYTES(sp)
-	LOAD	x15, 15 * REGBYTES(sp)
-	LOAD	x16, 16 * REGBYTES(sp)
-	LOAD	x17, 17 * REGBYTES(sp)
-	LOAD	x18, 18 * REGBYTES(sp)
-	LOAD	x19, 19 * REGBYTES(sp)
-	LOAD	x20, 20 * REGBYTES(sp)
-	LOAD	x21, 21 * REGBYTES(sp)
-	LOAD	x22, 22 * REGBYTES(sp)
-	LOAD	x23, 23 * REGBYTES(sp)
-	LOAD	x24, 24 * REGBYTES(sp)
-	LOAD	x25, 25 * REGBYTES(sp)
-	LOAD	x26, 26 * REGBYTES(sp)
-	LOAD	x27, 27 * REGBYTES(sp)
-	LOAD	x28, 28 * REGBYTES(sp)
-	LOAD	x29, 29 * REGBYTES(sp)
-	LOAD	x30, 30 * REGBYTES(sp)
-	LOAD	x31, 31 * REGBYTES(sp)
-
-	addi	sp, sp, REGBYTES * 34
+    addi    sp, sp, REGBYTES * 36
 .endm
 
-/* Interrupt entry point */
-trap_entry:
-	/* Check for interrupt */
-	pushREGFILE
-	SET_INT_CONTEXT
-	csrr	a0, mcause
-	blt		a0,zero,interrupt
-
-	/* synchronous interrupt*/
-	/* pass sp in a1 */
-	mv a1,sp
-	jal ulSynchTrap
-/*  adjust stack pointer back to where it was prior to ulSynchTrap  */
-	mv		sp,a0
-	CLEAR_INT_CONTEXT
-	popREGFILE
-	mret
-
-/* async interrupt, this function is called */
-interrupt:
-	li      t0,INT_MASK
-	and     a0,a0,t0
-	li      t0, 0x7
-	beq     a0,t0, MTIME_IRQ
-	/* Interupt not m-time interrupt */
-	/* pass the exception code in a0 */
-	jal 	handle_interrupt
-	portRESTORE_X2
-	CLEAR_INT_CONTEXT
-	popREGFILE
-	mret
-
-	/* Interupt is m-time  */
-MTIME_IRQ:
-	portSAVE_CONTEXT
-	portSAVE_EPC
-	jal		vPortSysTickHandler
-	portRESTORE_CONTEXT
-	CLEAR_INT_CONTEXT
-	popREGFILE
-	mret
-
 xPortStartScheduler:
-	jal		vPortSetup
-	portRESTORE_CONTEXT
-	popREGFILE
-	mret
-
+    jal vPortSetup
+    portRESTORE_CONTEXT
+    popREGFILE
+    mret
 
 vPortYield:
-/*  adjust stack pointer back to where it was prior to ulSynchTrap  */
-	mv		sp,a0
-	portSAVE_CONTEXT
-
-/* context return point was passed back to this function in a1 */
-	STORE	a1, 33 * REGBYTES(sp)
-    /* switch context */
-	jal		vTaskSwitchContext
-	portRESTORE_CONTEXT
-	CLEAR_INT_CONTEXT
-	popREGFILE
-	mret
+    csrr  a0, mepc
+    ADDI  a0, a0, 4
+    STORE a0, 33 * REGBYTES(sp)
+    portSAVE_CONTEXT
+    jal vTaskSwitchContext
+    portRESTORE_CONTEXT
+    CLEAR_INT_CONTEXT
+    popREGFILE
+    mret
 
 vPortEndScheduler:
 1:
-	j		1b
+    j 1b
 
 
 .weak handle_interrupt

--- a/WD-Firmware/rtos/rtosal/api_inc/rtosal_config.h
+++ b/WD-Firmware/rtos/rtosal/api_inc/rtosal_config.h
@@ -30,23 +30,23 @@
 //[OS]: TODO: need to add the min stack size for both RTOS
    
 #ifdef D_USE_FREERTOS
-   #include "FreeRTOS.h"
+//   #include "FreeRTOS.h"
 #if (configSUPPORT_STATIC_ALLOCATION!=1) || (configSUPPORT_DYNAMIC_ALLOCATION!=0)
-   #error *** RTOSAL port to FreeRTOS supports only static allocation ***
-   #error *** please set configSUPPORT_STATIC_ALLOCATION to 1 and configSUPPORT_DYNAMIC_ALLOCATION to 0 in FreeRTOSConfig.h ***
+//   #error *** RTOSAL port to FreeRTOS supports only static allocation ***
+//   #error *** please set configSUPPORT_STATIC_ALLOCATION to 1 and configSUPPORT_DYNAMIC_ALLOCATION to 0 in FreeRTOSConfig.h ***
 #endif /* #if (configSUPPORT_STATIC_ALLOCATION!=1) || (configSUPPORT_DYNAMIC_ALLOCATION!=0) */
 
 #elif D_USE_THREADX
    #include "TBD: the root api"
 #else
-   #error *** RTOSAL: undefined RTOS core (use D_USE_THREADX/D_USE_THREADX) ***
+   #error *** RTOSAL: undefined RTOS core (use D_USE_FREERTOS/D_USE_THREADX) ***
 #endif /* #ifdef D_USE_FREERTOS */
 
 /**
 * definitions
 */
 #ifdef D_USE_FREERTOS
-   #define D_RTOSAL_ERROR_CHECK                  1
+   #define D_RTOSAL_ERROR_CHECK                  0
 #elif D_USE_THREADX
    #define D_RTOSAL_ERROR_CHECK                  TBD_TAKE_VAL_FROM_TX
 #endif /* #ifdef D_USE_FREERTOS */

--- a/WD-Firmware/rtos/rtosal/api_inc/rtosal_defines.h
+++ b/WD-Firmware/rtos/rtosal/api_inc/rtosal_defines.h
@@ -143,24 +143,4 @@
    #define D_RTOSAL_NO_TIME_SLICE                TBD_TAKE_VAL_FROM_TX
 #endif /* #ifdef D_USE_FREERTOS */
 
-/**
-* macros
-*/
-
-/**
-* types
-*/
-
-/**
-* local prototypes
-*/
-
-/**
-* external prototypes
-*/
-
-/**
-* global variables
-*/
-
 #endif /* __RTOSAL_DEFINES_H__ */

--- a/WD-Firmware/rtos/rtosal/api_inc/rtosal_macro.h
+++ b/WD-Firmware/rtos/rtosal/api_inc/rtosal_macro.h
@@ -30,6 +30,7 @@
 /**
 * macros
 */
+/* error checking macro */
 #if (D_RTOSAL_ERROR_CHECK==1)
    #define M_RTOSAL_VALIDATE_FUNC_PARAM(param, conditionMet, returnCode) \
       if (conditionMet) \
@@ -40,5 +41,7 @@
 #else
    #define M_RTOSAL_VALIDATE_FUNC_PARAM(param, conditionMet, returnCode)
 #endif /* #if (D_RTOSAL_ERROR_CHECK==1) */
+
+#define RTOSAL_SECTION __attribute__((section("RTOSAL_SEC")))
 
 #endif /* __RTOSAL_MACRO_H__ */

--- a/WD-Firmware/rtos/rtosal/api_inc/rtosal_task_api.h
+++ b/WD-Firmware/rtos/rtosal/api_inc/rtosal_task_api.h
@@ -29,7 +29,7 @@
 #include "rtosal_config.h"
 #include "rtosal_defines.h"
 #include "rtosal_types.h"
-
+#include "rtosal_macro.h"
 /**
 * definitions
 */

--- a/WD-Firmware/rtos/rtosal/api_inc/rtosal_types.h
+++ b/WD-Firmware/rtos/rtosal/api_inc/rtosal_types.h
@@ -28,9 +28,31 @@
 * include files
 */
 #include "common_types.h"
-
+#ifdef D_USE_FREERTOS
+   #include "FreeRTOS.h"
+#endif /* #ifdef D_USE_FREERTOS */
 /**
 * types
 */
+#ifdef D_USE_FREERTOS
+   typedef u32_t rtosalStackType_t;
+#elif D_USE_THREADX
+   #error *** TODO: need to define the TBD ***
+   typedef TBD   rtosalStackType_t;
+#endif /* #ifdef D_USE_FREERTOS */
+
+#ifdef D_USE_FREERTOS
+   typedef StaticTask_t rtosalStaticTask_t;
+#elif D_USE_THREADX
+   #error *** TODO: need to define the TBD ***
+   typedef TBD        rtosalStaticTask_t;
+#endif /* #ifdef D_USE_FREERTOS */
+
+#ifdef D_USE_FREERTOS
+   typedef StackType_t rtosalStack_t;
+#elif D_USE_THREADX
+   #error *** TODO: need to define the TBD ***
+   typedef TBD         rtosalStack_t;
+#endif /* __RTOSAL_TYPES_H__ */
 
 #endif /* __RTOSAL_TYPES_H__ */

--- a/WD-Firmware/rtos/rtosal/api_inc/rtosal_util_api.h
+++ b/WD-Firmware/rtos/rtosal/api_inc/rtosal_util_api.h
@@ -50,6 +50,7 @@ typedef void (*rtosalParamErrorNotification_t)(const void *pParam, u32_t uiError
 /**
 * local prototypes
 */
+void rtosalContextSwitchIndicationClear(void);
 
 /**
 * external prototypes
@@ -62,22 +63,20 @@ typedef void (*rtosalParamErrorNotification_t)(const void *pParam, u32_t uiError
 /**
 * APIs
 */
+
 /**
 * This API initializes the RTOS and triggers the scheduler operation
-*
-* @param None
-*
-* @return calling this function will never return
 */
 void rtosalStart(rtosalApplicationInit_t fptrInit);
 
 /**
 * Set param error notification function
-*
-* @param fptrRtosalParamErrorNotification - notification function
-*
-* @return none
 */
 void rtosalParamErrorNotifyFuncSet(rtosalParamErrorNotification_t fptrRtosalParamErrorNotification);
+
+/**
+* This function is invoked by the system timer interrupt
+*/
+void rtosalTick(void);
 
 #endif /* __RTOSAL_UTIL_API_H__ */

--- a/WD-Firmware/rtos/rtosal/rtosal_event.c
+++ b/WD-Firmware/rtos/rtosal/rtosal_event.c
@@ -68,7 +68,7 @@
 *                          - D_RTOSAL_GROUP_ERROR - the group CB is invalid or been used
 *                          - D_RTOSAL_CALLER_ERR - the caller can not call this function 
 */
-u32_t rtosalEventGroupCreate(rtosalEventGroup_t* pRtosalEventGroupCb, s08_t* pRtosalEventGroupName)
+RTOSAL_SECTION u32_t rtosalEventGroupCreate(rtosalEventGroup_t* pRtosalEventGroupCb, s08_t* pRtosalEventGroupName)
 {
    u32_t uiRes;
 
@@ -109,7 +109,7 @@ u32_t rtosalEventGroupCreate(rtosalEventGroup_t* pRtosalEventGroupCb, s08_t* pRt
 *                         - D_RTOSAL_GROUP_ERROR - the group CB is invalid or been used
 *                         - D_RTOSAL_CALLER_ERR - the caller can not call this function 
 */
-u32_t rtosalEventGroupDestroy(rtosalEventGroup_t* pRtosalEventGroupCb)
+RTOSAL_SECTION u32_t rtosalEventGroupDestroy(rtosalEventGroup_t* pRtosalEventGroupCb)
 {
    u32_t uiRes;
 
@@ -139,7 +139,7 @@ u32_t rtosalEventGroupDestroy(rtosalEventGroup_t* pRtosalEventGroupCb)
 *                        - D_RTOSAL_OPTION_ERROR - bad param on uiSetOption
 *                        - D_RTOSAL_FAIL - fail to set event
 */
-u32_t rtosalEventGroupSet(rtosalEventGroup_t* pRtosalEventGroupCb,
+RTOSAL_SECTION u32_t rtosalEventGroupSet(rtosalEventGroup_t* pRtosalEventGroupCb,
                           rtosalEventBits_t stSetRtosalEventBits,
                           u32_t uiSetOption, rtosalEventBits_t* pRtosalEventBits)
 {
@@ -154,7 +154,7 @@ u32_t rtosalEventGroupSet(rtosalEventGroup_t* pRtosalEventGroupCb,
 
 #ifdef D_USE_FREERTOS
    /* rtosalEventGroupSet invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       uiRes = xEventGroupSetBitsFromISR(pRtosalEventGroupCb->eventGroupHandle,
                                       stSetRtosalEventBits, &xHigherPriorityTaskWoken);
@@ -216,7 +216,7 @@ u32_t rtosalEventGroupSet(rtosalEventGroup_t* pRtosalEventGroupCb,
 *                        - D_RTOSAL_WAIT_ERROR - illegal use of wait (wait can be used only from thread)
 *                        - D_RTOSAL_OPTION_ERROR - bad uiRetrieveOption
 */
-u32_t rtosalEventGroupGet(rtosalEventGroup_t* pRtosalEventGroupCb, u32_t uiRetrieveEvents,
+RTOSAL_SECTION u32_t rtosalEventGroupGet(rtosalEventGroup_t* pRtosalEventGroupCb, u32_t uiRetrieveEvents,
                           rtosalEventBits_t* pRtosalEventBits, u32_t uiRetrieveOption,
                           u32_t uiWaitTimeoutTicks)
 {
@@ -231,7 +231,7 @@ u32_t rtosalEventGroupGet(rtosalEventGroup_t* pRtosalEventGroupCb, u32_t uiRetri
    M_RTOSAL_VALIDATE_FUNC_PARAM(pRtosalEventBits, pRtosalEventBits == NULL, D_RTOSAL_GROUP_ERROR);
 
    /* invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       *pRtosalEventBits = xEventGroupGetBitsFromISR(pRtosalEventGroupCb->eventGroupHandle);
    }

--- a/WD-Firmware/rtos/rtosal/rtosal_int_vect.S
+++ b/WD-Firmware/rtos/rtosal/rtosal_int_vect.S
@@ -1,0 +1,240 @@
+/*
+    FreeRTOS V8.2.3 - Copyright (C) 2015 Real Time Engineers Ltd.
+    All rights reserved
+
+    VISIT http://www.FreeRTOS.org TO ENSURE YOU ARE USING THE LATEST VERSION.
+
+    This file is part of the FreeRTOS distribution and was contributed
+    to the project by Technolution B.V. (www.technolution.nl,
+    freertos-riscv@technolution.eu) under the terms of the FreeRTOS
+    contributors license.
+
+    FreeRTOS is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License (version 2) as published by the
+    Free Software Foundation >>>> AND MODIFIED BY <<<< the FreeRTOS exception.
+
+    ***************************************************************************
+    >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+    >>!   distribute a combined work that includes FreeRTOS without being   !<<
+    >>!   obliged to provide the source code for proprietary components     !<<
+    >>!   outside of the FreeRTOS kernel.                                   !<<
+    ***************************************************************************
+
+    FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+    link: http://www.freertos.org/a00114.html
+
+    ***************************************************************************
+     *                                                                       *
+     *    FreeRTOS provides completely free yet professionally developed,    *
+     *    robust, strictly quality controlled, supported, and cross          *
+     *    platform software that is more than just the market leader, it     *
+     *    is the industry''s de facto standard.                               *
+     *                                                                       *
+     *    Help yourself get started quickly while simultaneously helping     *
+     *    to support the FreeRTOS project by purchasing a FreeRTOS           *
+     *    tutorial book, reference manual, or both:                          *
+     *    http://www.FreeRTOS.org/Documentation                              *
+     *                                                                       *
+    ***************************************************************************
+
+    http://www.FreeRTOS.org/FAQHelp.html - Having a problem?  Start by reading
+    the FAQ page "My application does not run, what could be wrong?".  Have you
+    defined configASSERT()?
+
+    http://www.FreeRTOS.org/support - In return for receiving this top quality
+    embedded software for free we request you assist our global community by
+    participating in the support forum.
+
+    http://www.FreeRTOS.org/training - Investing in training allows your team to
+    be as productive as possible as early as possible.  Now you can receive
+    FreeRTOS training directly from Richard Barry, CEO of Real Time Engineers
+    Ltd, and the world's leading authority on the world's leading RTOS.
+
+    http://www.FreeRTOS.org/plus - A selection of FreeRTOS ecosystem products,
+    including FreeRTOS+Trace - an indispensable productivity tool, a DOS
+    compatible FAT file system, and our tiny thread aware UDP/IP stack.
+
+    http://www.FreeRTOS.org/labs - Where new FreeRTOS products go to incubate.
+    Come and try FreeRTOS+TCP, our new open source TCP/IP stack for FreeRTOS.
+
+    http://www.OpenRTOS.com - Real Time Engineers ltd. license FreeRTOS to High
+    Integrity Systems ltd. to sell under the OpenRTOS brand.  Low cost OpenRTOS
+    licenses offer ticketed support, indemnification and commercial middleware.
+
+    http://www.SafeRTOS.com - High Integrity Systems also provide a safety
+    engineered and independently SIL3 certified version for use in safety and
+    mission critical applications that require provable dependability.
+
+    1 tab == 4 spaces!
+*/
+
+/*
+This implementation supports riscv privileged v1.10
+*/
+.include "psp_asm_macros.h"
+
+/* saves mstatus and tcb */
+.macro m_portSAVE_CONTEXT
+    .global    pxCurrentTCB
+    /* Store mstatus */
+    csrr      t0, mstatus
+    m_STORE   t0, 32 * REGBYTES(sp)
+    /* Store current stackpointer in task control block (TCB) */
+    m_LOAD    t0, pxCurrentTCB
+    m_STORE   sp, 0x0(t0)
+.endm
+
+ /* restore mstatus and tcb */
+.macro m_portRESTORE_CONTEXT
+    .global    pxCurrentTCB
+    /* Load stack pointer from the current TCB */
+    m_LOAD    sp, pxCurrentTCB
+    m_LOAD    sp, 0x0(sp)
+    /* Load task program counter */
+    m_LOAD    t0, 33 * REGBYTES(sp)
+    csrw      mepc, t0
+    /* Load saved mstatus */
+    m_LOAD    t0, 32 * REGBYTES(sp)
+    csrw      mstatus, t0
+.endm
+
+.macro m_portEND_SWITCHING_ISR brunch_label
+    /* save address of g_rtosalContextSwitch -> a0 */
+    la        a0, g_rtosalContextSwitch
+    /* load the value g_rtosalContextSwitch -> a1 */
+    m_LOAD    a1, 0x0(a0)
+    /* check if g_rtosalContextSwitch is set - need to do context switch */
+    beqz      a1, \brunch_label
+    /* clear g_rtosalContextSwitch */
+    /* TODO: if bitmanip exist add bit set */
+    m_STORE   zero, 0x0(a0)
+    /* perform context switch */
+.if D_USE_FREERTOS
+    m_portSAVE_CONTEXT
+    jal     vTaskSwitchContext
+    m_portRESTORE_CONTEXT
+.elseif D_USE_THREADX
+.endif /* .if D_USE_FREERTOS */
+.endm
+
+/* Saves current Machine Exception Program Counter (MEPC) as task program counter */
+.macro m_portSAVE_EPC
+    csrr      t0, mepc
+    m_STORE   t0, 33 * REGBYTES(sp)
+.endm
+
+/* Saves current return adress (RA) as task program counter */
+.macro m_portSAVE_RA
+    LOAD      t0, 1 * REGBYTES(sp)
+    m_STORE   t0, 33 * REGBYTES(sp)
+.endm
+
+/*/not called on a context switch*/
+.macro m_portRESTORE_SP
+    m_LOAD    x2, 2 * REGBYTES(sp)
+.endm
+
+.section  .text.entry
+.align 4
+.global   rtosal_vect_table
+
+.ifndef D_RTOSAL_VECT_TABLE
+rtosal_vect_table:
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+    csrr    t0, mcause
+    bge     t0, zero, rtosal_vect_table_
+    slli    t0, t0, 2
+    la      t1, rtosal_vect_table_
+    add     t0, t0, t1
+    jr      t0
+.endif /* #if D_RTOSAL_VECT_TABLE */
+
+.align 4
+.ifndef D_RTOSAL_VECT_TABLE
+rtosal_vect_table_:
+.else
+rtosal_vect_table:
+.endif /* #if D_RTOSAL_VECT_TABLE */
+    j       rtosa_exceptions_int       /* User software interrupt & exceptions */
+    .align 2
+    j       rtosa_reserved_int         /* Supervisor software interrupt        */
+    .align 2
+    j       rtosa_reserved_int         /* Reserved for future standard use     */
+    .align 2
+    j       rtosa_m_soft_int           /* Machine software interrupt           */
+    .align 2
+    j       rtosa_reserved_int         /* User timer interrupt                 */
+    .align 2
+    j       rtosa_reserved_int         /* Supervisor timer interrupt           */
+    .align 2
+    j       rtosa_reserved_int         /* Reserved for future standard use     */
+    .align 2
+    j       rtosa_m_timer_int          /* Machine timer interrupt              */
+    .align 2
+    j       rtosa_reserved_int         /* User external interrupt              */
+    .align 2
+    j       rtosa_reserved_int         /* Supervisor external interrupt        */
+    .align 2
+    j       rtosa_reserved_int         /* Reserved for future standard use     */
+    .align 2
+    j       rtosa_m_external_int       /* Machine external interrupt           */
+    .align 2
+
+rtosa_exceptions_int:
+.ifdef D_RTOSAL_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_RTOSAL_VECT_TABLE */
+    /* call the exception handler */
+    m_CALL_INT_HANDLER g_fptrIntExceptionIntHandler
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+rtosa_m_soft_int:
+.ifdef D_RTOSAL_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_RTOSAL_VECT_TABLE */
+    m_CALL_INT_HANDLER g_fptrIntMSoftIntHandler
+    m_portEND_SWITCHING_ISR rtosa_m_soft_int_no_cs
+rtosa_m_soft_int_no_cs:
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+rtosa_m_timer_int:
+.ifdef D_RTOSAL_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_RTOSAL_VECT_TABLE */
+    m_portSAVE_CONTEXT
+    m_portSAVE_EPC
+    m_CALL_INT_HANDLER g_fptrIntMTimerIntHandler
+    m_portRESTORE_CONTEXT
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+rtosa_m_external_int:
+.ifdef D_RTOSAL_VECT_TABLE
+    m_pushREGFILE
+    m_SET_INT_CONTEXT
+.endif /* D_RTOSAL_VECT_TABLE */
+    m_CALL_INT_HANDLER g_fptrIntMExternIntHandler
+    m_portRESTORE_SP
+    m_portEND_SWITCHING_ISR rtosa_m_external_int_no_cs
+rtosa_m_external_int_no_cs:
+    m_CLEAR_INT_CONTEXT
+    m_popREGFILE
+    mret
+
+.weak rtosa_reserved_int
+rtosa_reserved_int:
+1:
+    nop
+    nop
+    j 1b

--- a/WD-Firmware/rtos/rtosal/rtosal_mutex.c
+++ b/WD-Firmware/rtos/rtosal/rtosal_mutex.c
@@ -69,7 +69,7 @@
 *                        - D_RTOSAL_CALLER_ERROR - the caller can not call this function 
 *                        - D_RTOSAL_INHERIT_ERROR - bad parm on uiPriorityInherit
 */
-u32_t rtosalMutexCreate(rtosalMutex_t* pRtosalMutexCb, s08_t* pRtosalMutexName, u32_t uiPriorityInherit)
+RTOSAL_SECTION u32_t rtosalMutexCreate(rtosalMutex_t* pRtosalMutexCb, s08_t* pRtosalMutexName, u32_t uiPriorityInherit)
 {
    u32_t uiRes;
 
@@ -108,7 +108,7 @@ u32_t rtosalMutexCreate(rtosalMutex_t* pRtosalMutexCb, s08_t* pRtosalMutexName, 
 *                    - D_RTOSAL_MUTEX_ERROR - the group pRtosalMutexCb is invalid or been used
 *                    - D_RTOSAL_CALLER_ERROR - the caller can not call this function
 */
-u32_t rtosalMutexDestroy(rtosalMutex_t* pRtosalMutexCb)
+RTOSAL_SECTION u32_t rtosalMutexDestroy(rtosalMutex_t* pRtosalMutexCb)
 {
    u32_t uiRes;
 
@@ -141,7 +141,7 @@ u32_t rtosalMutexDestroy(rtosalMutex_t* pRtosalMutexCb)
 *                         - D_RTOSAL_WAIT_ERROR - illegal use of wait (wait can be used only from thread)
 *                         - D_RTOSAL_CALLER_ERROR - the caller can not call this function 
 */
-u32_t rtosalMutexWait(rtosalMutex_t* pRtosalMutexCb, u32_t uiWaitTimeoutTicks)
+RTOSAL_SECTION u32_t rtosalMutexWait(rtosalMutex_t* pRtosalMutexCb, u32_t uiWaitTimeoutTicks)
 {
    u32_t uiRes;
 
@@ -175,7 +175,7 @@ u32_t rtosalMutexWait(rtosalMutex_t* pRtosalMutexCb, u32_t uiWaitTimeoutTicks)
 *                    - D_RTOSAL_MUTEX_ERROR - the ptr in the mutex CB is invalid
 *                    - D_RTOSAL_CALLER_ERROR - the caller can not call this function 
 */
-u32_t rtosalMutexRelease(rtosalMutex_t* pRtosalMutexCb)
+RTOSAL_SECTION u32_t rtosalMutexRelease(rtosalMutex_t* pRtosalMutexCb)
 {
    u32_t uiRes;
 

--- a/WD-Firmware/rtos/rtosal/rtosal_queue.c
+++ b/WD-Firmware/rtos/rtosal/rtosal_queue.c
@@ -78,7 +78,7 @@ D_INLINE D_ALWAYS_INLINE u32_t msgQueueSend(rtosalMsgQueue_t* pRtosalMsgQueueCb,
 *                             - D_RTOSAL_SIZE_ERROR   - Invalid uiRtosMsgQueueSize
 *                             - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosalMsgQueueCreate(rtosalMsgQueue_t* pRtosalMsgQueueCb, void* pRtosMsgQueueBuffer,
+RTOSAL_SECTION u32_t rtosalMsgQueueCreate(rtosalMsgQueue_t* pRtosalMsgQueueCb, void* pRtosMsgQueueBuffer,
                            u32_t uiRtosMsgQueueSize, u32_t uiRtosMsgQueueItemSize,
                            s08_t* pRtosalMsgQueueName)
 {
@@ -122,7 +122,7 @@ u32_t rtosalMsgQueueCreate(rtosalMsgQueue_t* pRtosalMsgQueueCb, void* pRtosMsgQu
 *                        - D_RTOSAL_QUEUE_ERROR - the ptr, MsgQueueCB, in the pRtosalMsgQueueCb is invalid
 *                        - D_RTOSAL_CALLER_ERROR - the caller can not call this function
 */
-u32_t rtosalMsgQueueDestroy(rtosalMsgQueue_t* pRtosalMsgQueueCb)
+RTOSAL_SECTION u32_t rtosalMsgQueueDestroy(rtosalMsgQueue_t* pRtosalMsgQueueCb)
 {
    u32_t uiRes;
 
@@ -159,7 +159,7 @@ u32_t rtosalMsgQueueDestroy(rtosalMsgQueue_t* pRtosalMsgQueueCb)
 *                          - D_RTOSAL_WAIT_ERROR - invalide uiWaitTimeoutTicks: if caller is not a thread it 
 *                                                   must use "NO WAIT"
 */
-u32_t rtosalMsgQueueSend(rtosalMsgQueue_t* pRtosalMsgQueueCb, const void* pRtosalMsgQueueItem,
+RTOSAL_SECTION u32_t rtosalMsgQueueSend(rtosalMsgQueue_t* pRtosalMsgQueueCb, const void* pRtosalMsgQueueItem,
                        u32_t uiWaitTimeoutTicks, u32_t uiSendToFront)
 {
    return msgQueueSend(pRtosalMsgQueueCb, pRtosalMsgQueueItem,
@@ -181,7 +181,7 @@ D_INLINE D_ALWAYS_INLINE u32_t msgQueueSend(rtosalMsgQueue_t* pRtosalMsgQueueCb,
    if (uiSendToFront == D_RTOSAL_TRUE)
    {
       /* msgQueueSend invoked from an ISR context */
-      if (pspIsInterruptContext() == D_INT_CONTEXT)
+      if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
       {
          /* send the queue message */
          uiRes = xQueueSendToFrontFromISR(pRtosalMsgQueueCb->msgQueueHandle, pRtosalMsgQueueItem, &xHigherPriorityTaskWoken);
@@ -195,7 +195,7 @@ D_INLINE D_ALWAYS_INLINE u32_t msgQueueSend(rtosalMsgQueue_t* pRtosalMsgQueueCb,
    else
    {
       /* msgQueueSend invoked from an ISR context */
-      if (pspIsInterruptContext() == D_INT_CONTEXT)
+      if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
       {
          uiRes = xQueueSendToBackFromISR(pRtosalMsgQueueCb->msgQueueHandle, pRtosalMsgQueueItem, &xHigherPriorityTaskWoken);
       }
@@ -280,7 +280,7 @@ u32_t rtosalMsgQueueRecieve(rtosalMsgQueue_t* pRtosalMsgQueueCb, void* pRtosalMs
 #ifdef D_USE_FREERTOS
    M_RTOSAL_VALIDATE_FUNC_PARAM(pRtosalMsgQueueDstBuf, pRtosalMsgQueueDstBuf == NULL, D_RTOSAL_PTR_ERROR);
    /* rtosalMsgQueueRecieve invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       uiRes = xQueueReceiveFromISR(pRtosalMsgQueueCb->msgQueueHandle, pRtosalMsgQueueDstBuf, &xHigherPriorityTaskWoken);
    }

--- a/WD-Firmware/rtos/rtosal/rtosal_semaphore.c
+++ b/WD-Firmware/rtos/rtosal/rtosal_semaphore.c
@@ -69,7 +69,7 @@
 *                                - D_RTOSAL_SEMAPHORE_ERROR - The ptr, cMsgQueueCB, in the pRtosalSemaphoreCb is invalid
 *                                - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosalSemaphoreCreate(rtosalSemaphore_t* pRtosalSemaphoreCb, s08_t *pRtosalSemaphoreName,
+RTOSAL_SECTION u32_t rtosalSemaphoreCreate(rtosalSemaphore_t* pRtosalSemaphoreCb, s08_t *pRtosalSemaphoreName,
                             s32_t iSemaphoreInitialCount, u32_t uiSemaphoreMaxCount)
 {
    u32_t uiRes;
@@ -109,7 +109,7 @@ u32_t rtosalSemaphoreCreate(rtosalSemaphore_t* pRtosalSemaphoreCb, s08_t *pRtosa
 *                         - D_RTOSAL_SEMAPHORE_ERROR - The ptr, cMsgQueueCB, in the pRtosalSemaphoreCb is invalid
 *                         - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosalSemaphoreDestroy(rtosalSemaphore_t* pRtosalSemaphoreCb)
+RTOSAL_SECTION u32_t rtosalSemaphoreDestroy(rtosalSemaphore_t* pRtosalSemaphoreCb)
 {
    u32_t uiRes;
 
@@ -142,7 +142,7 @@ u32_t rtosalSemaphoreDestroy(rtosalSemaphore_t* pRtosalSemaphoreCb)
 *                          - D_RTOSAL_WAIT_ERROR - Invalide uiWaitTimeoutTicks: if caller is not a thread it 
 *                                                   must use "NO WAIT"
 */
-u32_t rtosalSemaphoreWait(rtosalSemaphore_t* pRtosalSemaphoreCb, u32_t uiWaitTimeoutTicks)
+RTOSAL_SECTION u32_t rtosalSemaphoreWait(rtosalSemaphore_t* pRtosalSemaphoreCb, u32_t uiWaitTimeoutTicks)
 {
    u32_t uiRes;
 #ifdef D_USE_FREERTOS
@@ -154,7 +154,7 @@ u32_t rtosalSemaphoreWait(rtosalSemaphore_t* pRtosalSemaphoreCb, u32_t uiWaitTim
 
 #ifdef D_USE_FREERTOS
    /* rtosalSemaphoreWait invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       uiRes = xSemaphoreTakeFromISR(pRtosalSemaphoreCb->semaphoreHandle, &xHigherPriorityTaskWoken);
    }
@@ -193,7 +193,7 @@ u32_t rtosalSemaphoreWait(rtosalSemaphore_t* pRtosalSemaphoreCb, u32_t uiWaitTim
 * @return u32_t           - D_RTOSAL_SUCCESS
 *                         - D_RTOSAL_SEMAPHORE_ERROR - The ptr, cMsgQueueCB, in the pRtosalSemaphoreCb is invalid
 */
-u32_t rtosalSemaphoreRelease(rtosalSemaphore_t* pRtosalSemaphoreCb)
+RTOSAL_SECTION u32_t rtosalSemaphoreRelease(rtosalSemaphore_t* pRtosalSemaphoreCb)
 {
    u32_t uiRes;
 #ifdef D_USE_FREERTOS
@@ -205,7 +205,7 @@ u32_t rtosalSemaphoreRelease(rtosalSemaphore_t* pRtosalSemaphoreCb)
 
 #ifdef D_USE_FREERTOS
    /* rtosalSemaphoreRelease invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       uiRes = xSemaphoreGiveFromISR(pRtosalSemaphoreCb->semaphoreHandle, &xHigherPriorityTaskWoken);
    }

--- a/WD-Firmware/rtos/rtosal/rtosal_task.c
+++ b/WD-Firmware/rtos/rtosal/rtosal_task.c
@@ -86,7 +86,7 @@
 *                                  - D_RTOSAL_START_ERROR - Invalid uiAutoStart
 *                                  - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosalTaskCreate(rtosalTask_t* pRtosalTaskCb, const s08_t* pTaskName, rtosalPriority_t uiPriority,
+RTOSAL_SECTION u32_t rtosalTaskCreate(rtosalTask_t* pRtosalTaskCb, const s08_t* pTaskName, rtosalPriority_t uiPriority,
                      rtosalTaskHandler_t fptrRtosTaskEntryPoint, u32_t uiTaskEntryPointParameter,
                      u32_t uiStackSize, void * pStackBuffer, u32_t uiTimeSliceTicks,
                      u32_t uiAutoStart, u32_t uiPreemptThuiReshold)
@@ -135,7 +135,7 @@ u32_t rtosalTaskCreate(rtosalTask_t* pRtosalTaskCb, const s08_t* pTaskName, rtos
 *                                              the task is not idle
 *                    - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosalTaskDestroy(rtosalTask_t* pRtosalTaskCb)
+RTOSAL_SECTION u32_t rtosalTaskDestroy(rtosalTask_t* pRtosalTaskCb)
 {
    u32_t uiRes;
 
@@ -166,7 +166,7 @@ u32_t rtosalTaskDestroy(rtosalTask_t* pRtosalTaskCb)
 *                      - D_RTOSAL_PTR_ERROR      - Invalid pOldPriority
 *                      - D_RTOSAL_CALLER_ERROR   - The caller can not call this function
 */
-u32_t rtosalTaskPriorityChange(rtosalTask_t* pRtosalTaskCb, u32_t uiNewPriority,
+RTOSAL_SECTION u32_t rtosalTaskPriorityChange(rtosalTask_t* pRtosalTaskCb, u32_t uiNewPriority,
                                u32_t *pOldPriority)
 {
    u32_t uiRes;
@@ -196,7 +196,7 @@ u32_t rtosalTaskPriorityChange(rtosalTask_t* pRtosalTaskCb, u32_t uiNewPriority,
 *
 * @return None
 */
-void rtosalTaskYield(void)
+RTOSAL_SECTION void rtosalTaskYield(void)
 {
 #ifdef D_USE_FREERTOS
    taskYIELD();
@@ -215,7 +215,7 @@ void rtosalTaskYield(void)
 *                     - D_RTOSAL_TASK_ERROR      - The ptr, cTaskCB, in the pRtosalTaskCb is invalid
 *                     - D_RTOSAL_RESUME_ERROR    - The task is not suspended 
 */
-u32_t rtosalTaskResume(rtosalTask_t* pRtosalTaskCb)
+RTOSAL_SECTION u32_t rtosalTaskResume(rtosalTask_t* pRtosalTaskCb)
 {
    u32_t uiRes;
 #ifdef D_USE_FREERTOS
@@ -227,7 +227,7 @@ u32_t rtosalTaskResume(rtosalTask_t* pRtosalTaskCb)
 
 #ifdef D_USE_FREERTOS
    /* rtosalTaskResume invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       /* if we uiResume from an ISR */
       uiRes = xTaskResumeFromISR(pRtosalTaskCb->taskHandle);
@@ -270,7 +270,7 @@ u32_t rtosalTaskResume(rtosalTask_t* pRtosalTaskCb)
 *                      - D_RTOSAL_WAIT_ABORTED - aborted by different consumer (like other thread)
 *                      - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosalTaskSleep(u32_t uiTimerTicks)
+RTOSAL_SECTION u32_t rtosalTaskSleep(u32_t uiTimerTicks)
 {
    u32_t uiRes;
 
@@ -295,7 +295,7 @@ u32_t rtosalTaskSleep(u32_t uiTimerTicks)
 *                     - D_RTOSAL_SUSPEND_ERROR - The task is "done state" like terminated
 *                     - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosalTaskSuspend(rtosalTask_t* pRtosalTaskCb)
+RTOSAL_SECTION u32_t rtosalTaskSuspend(rtosalTask_t* pRtosalTaskCb)
 {
    u32_t uiRes;
 
@@ -321,7 +321,7 @@ u32_t rtosalTaskSuspend(rtosalTask_t* pRtosalTaskCb)
 *                    - D_RTOSAL_TASK_ERROR - The ptr, cTaskCB, in the pRtosalTaskCb is invalid
 *                    - D_RTOSAL_WAIT_ABORT_ERROR - The task is not in a block/wait state
 */
-u32_t rtosalTaskWaitAbort(rtosalTask_t* pRtosalTaskCb)
+RTOSAL_SECTION u32_t rtosalTaskWaitAbort(rtosalTask_t* pRtosalTaskCb)
 {
    u32_t uiRes;
 

--- a/WD-Firmware/rtos/rtosal/rtosal_time.c
+++ b/WD-Firmware/rtos/rtosal/rtosal_time.c
@@ -82,7 +82,7 @@
 *                          - D_RTOSAL_ACTIVATE_ERROR - Invalid uiAutoActivate
 *                          - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosTimerCreate(rtosalTimer_t* pRtosalTimerCb, s08_t *pRtosTimerName,
+RTOSAL_SECTION u32_t rtosTimerCreate(rtosalTimer_t* pRtosalTimerCb, s08_t *pRtosTimerName,
                      rtosalTimerHandler_t fptrRtosTimerCallcabk,
 							u32_t uiTimeCallbackParam, u32_t uiAutoActivate,
 							u32_t uiTicks, u32_t uiRescheduleTicks)
@@ -140,7 +140,7 @@ u32_t rtosTimerCreate(rtosalTimer_t* pRtosalTimerCb, s08_t *pRtosTimerName,
 *                          - D_RTOSAL_TIMER_ERROR - The ptr, cTaskCB, in the pRtosalTimerCb is invalid
 *                          - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 */
-u32_t rtosTimerDestroy(rtosalTimer_t* pRtosalTimerCb)
+RTOSAL_SECTION u32_t rtosTimerDestroy(rtosalTimer_t* pRtosalTimerCb)
 {
    u32_t uiRes;
 
@@ -174,7 +174,7 @@ u32_t rtosTimerDestroy(rtosalTimer_t* pRtosalTimerCb)
 *                          - D_RTOSAL_ACTIVATE_ERROR - Timer is already running or already expried
 *                          - D_RTOSAL_FAIL - Timers was not activated, request to active was rejected
 */
-u32_t rtosTimerStart(rtosalTimer_t* pRtosalTimerCb)
+RTOSAL_SECTION u32_t rtosTimerStart(rtosalTimer_t* pRtosalTimerCb)
 {
    u32_t uiRes;
 #ifdef D_USE_FREERTOS
@@ -186,7 +186,7 @@ u32_t rtosTimerStart(rtosalTimer_t* pRtosalTimerCb)
 
 #ifdef D_USE_FREERTOS
    /* rtosTimerStart invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       uiRes = xTimerStartFromISR(pRtosalTimerCb->timerHandle, &xHigherPriorityTaskWoken);
    }
@@ -227,7 +227,7 @@ u32_t rtosTimerStart(rtosalTimer_t* pRtosalTimerCb)
 *                          - D_RTOSAL_TIMER_ERROR - The ptr, cTaskCB, in the pRtosalTimerCb is invalid
 *                          - D_RTOSAL_FAIL - Timers was not Stopped, request to stop was rejected
 */
-u32_t rtosTimerStop(rtosalTimer_t* pRtosalTimerCb)
+RTOSAL_SECTION u32_t rtosTimerStop(rtosalTimer_t* pRtosalTimerCb)
 {
    u32_t uiRes;
 #ifdef D_USE_FREERTOS
@@ -239,7 +239,7 @@ u32_t rtosTimerStop(rtosalTimer_t* pRtosalTimerCb)
 
 #ifdef D_USE_FREERTOS
    /* rtosTimerStop invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       uiRes = xTimerStopFromISR(pRtosalTimerCb->timerHandle, &xHigherPriorityTaskWoken);
    }
@@ -286,7 +286,7 @@ u32_t rtosTimerStop(rtosalTimer_t* pRtosalTimerCb)
 *                          - D_RTOSAL_CALLER_ERROR - The caller can not call this function
 *                          - D_RTOSAL_ACTIVATE_ERROR - Timer is already running or already expried
 */
-u32_t rtosTimerModifyPeriod(rtosalTimer_t* pRtosalTimerCb, u32_t uiTicks, u32_t uiRescheduleTicks)
+RTOSAL_SECTION u32_t rtosTimerModifyPeriod(rtosalTimer_t* pRtosalTimerCb, u32_t uiTicks, u32_t uiRescheduleTicks)
 {
    u32_t uiRes;
 #ifdef D_USE_FREERTOS
@@ -300,7 +300,7 @@ u32_t rtosTimerModifyPeriod(rtosalTimer_t* pRtosalTimerCb, u32_t uiTicks, u32_t 
 
 #ifdef D_USE_FREERTOS
    /* rtosTimerModifyPeriod invoked from an ISR context */
-   if (pspIsInterruptContext() == D_INT_CONTEXT)
+   if (pspIsInterruptContext() == D_PSP_INT_CONTEXT)
    {
       uiRes = xTimerChangePeriodFromISR(pRtosalTimerCb->timerHandle, uiTicks, &xHigherPriorityTaskWoken);
    }

--- a/WD-Firmware/rtos/rtosal/rtosal_util.c
+++ b/WD-Firmware/rtos/rtosal/rtosal_util.c
@@ -27,6 +27,7 @@
 */
 #include "rtosal_util_api.h"
 #include "rtosal.h"
+#include "rtosal_macro.h"
 #ifdef D_USE_FREERTOS
    #include "task.h"
 #endif /* #ifdef D_USE_FREERTOS */
@@ -58,6 +59,7 @@ extern void rtosalParamErrorNotification(const void *pParam, u32_t uiErrorCode);
 */
 rtosalParamErrorNotification_t fptrParamErrorNotification = rtosalParamErrorNotification;
 rtosalApplicationInit_t  fptrAppInit = NULL;
+u32_t g_rtosalContextSwitch = 0;
 
 /**
 * This API initializes the RTOS and triggers the scheduler operation
@@ -67,7 +69,7 @@ rtosalApplicationInit_t  fptrAppInit = NULL;
 *
 * @return calling this function will never return
 */
-void rtosalStart(rtosalApplicationInit_t fptrInit)
+RTOSAL_SECTION void rtosalStart(rtosalApplicationInit_t fptrInit)
 {
 #ifdef D_USE_FREERTOS
    fptrInit(NULL);
@@ -85,7 +87,7 @@ void rtosalStart(rtosalApplicationInit_t fptrInit)
 *
 * @return none
 */
-void rtosalParamErrorNotifyFuncRegister(rtosalParamErrorNotification_t fptrRtosalParamErrorNotification)
+RTOSAL_SECTION void rtosalParamErrorNotifyFuncRegister(rtosalParamErrorNotification_t fptrRtosalParamErrorNotification)
 {
    fptrParamErrorNotification = fptrRtosalParamErrorNotification;
 }
@@ -97,8 +99,21 @@ void rtosalParamErrorNotifyFuncRegister(rtosalParamErrorNotification_t fptrRtosa
 *
 * @return none
 */
-void rtosalContextSwitchIndicationSet(void)
+RTOSAL_SECTION void rtosalContextSwitchIndicationSet(void)
 {
+	g_rtosalContextSwitch = 1;
+}
+
+/**
+*
+*
+* @param none
+*
+* @return none
+*/
+RTOSAL_SECTION void rtosalContextSwitchIndicationClear(void)
+{
+	g_rtosalContextSwitch = 0;
 }
 
 /**
@@ -109,9 +124,27 @@ void rtosalContextSwitchIndicationSet(void)
 * @return none
 */
 #ifdef D_USE_THREADX
-void tx_application_define(void *pMemory)
+RTOSAL_SECTION void tx_application_define(void *pMemory)
 {
    fptrAppInit(pMemory);
 }
-#endif /* #ifdef D_USE_FREERTOS */
+#endif /* #ifdef D_USE_THREADX */
 
+/**
+* This function is invoked by the system timer interrupt
+*
+* @param  none
+*
+* @return none
+*/
+RTOSAL_SECTION void rtosalTick(void)
+{
+#ifdef D_USE_FREERTOS
+   if (xTaskIncrementTick() == pdTRUE)
+   {
+      vTaskSwitchContext();
+   }
+#elif D_USE_THREADX
+   // call threadx
+#endif /* #ifdef D_USE_FREERTOS */
+}


### PR DESCRIPTION
* fix build for rtos demo
* Add types rtosalStaticTask_t, rtosalStack_t
* replace tabs with spaces
* add comments
* use GNU assembly preprocessor directives in .S files
* rename read_csr to M_PSP_READ_CSR
* for psp, have one include file which will include all other header files
* remove unused files
* change build configuration to support 2 demos
* remove common*.h from psp-api.h
* fix PSP typo name
* configuration description
* +g for all fptrInt*
* PSP_SECTION -> PSP_TEXT_SECTION
* Add PSP_DATA_SECTION
* Check CALL_INT_HANDLER jalr ???
* Change t0 to a_ (check what is in the elfdump)
* rtosal_default.c why extern?
* If we have rtosal global data add a new data section
* Remove rtosal_interrupt_cfg.c
* Rtosal int vect change macros to m_rtosal_name also for psp
* rtosal_int_vect.S j       vPortYieldFromInterrupt wrap with if def
* align stack frame to 16 in save/restore
* rename restore x2 macro
* add nops in reserved int hndler
* create macros for load/store 32/64 commands