### PR TITLE
Fix hifive1 bug

### DIFF
--- a/WD-Firmware/board/hifive1/link.lds
+++ b/WD-Firmware/board/hifive1/link.lds
@@ -144,6 +144,11 @@ SECTIONS
     *(.srodata .srodata.*)
   } >ram AT>flash :ram_init
 
+  PSP_DATA_SEC : 
+  {
+ 
+  } >ram AT>flash :ram_init
+  
   . = ALIGN(4);
   PROVIDE( _edata = . );
   PROVIDE( edata = . );
@@ -170,6 +175,8 @@ SECTIONS
     . = __stack_size;
     PROVIDE( _sp = . );
   } >ram AT>ram :ram
+
+ 
 
   /* this area is used for loading and executing the comrv 
      overlay groups */

--- a/WD-Firmware/board/nexys_a7_swerv_eh1/link.lds
+++ b/WD-Firmware/board/nexys_a7_swerv_eh1/link.lds
@@ -102,6 +102,11 @@ SECTIONS
     . = ALIGN(8);
   } > ram : ram_load
 
+  PSP_DATA_SEC : ALIGN(16)
+  {
+  
+  }  > ram : ram_load
+
   .sdata :
   {
     . = ALIGN(8);
@@ -113,6 +118,8 @@ SECTIONS
    . = ALIGN(8);
   } > ram : ram_load
 
+
+  
   . = ALIGN(4);
   PROVIDE( _edata = . );
   PROVIDE( edata = . );
@@ -136,8 +143,8 @@ SECTIONS
     . = . + __stack_size;
     _sp = .;
   } > ram : ram_load
-
-
+  
+  
   /* this area is used for loading and executing the comrv 
      overlay groups */
   .overlay_sec ALIGN(__comrv_align_size) :

--- a/WD-Firmware/psp/api_inc/psp_attributes.h
+++ b/WD-Firmware/psp/api_inc/psp_attributes.h
@@ -39,7 +39,7 @@
 #define D_PSP_16_ALIGNED                               __attribute__ ((aligned(16)))
 #define D_PSP_WEAK                                     __attribute__(( weak ))
 #define D_PSP_TEXT_SECTION                             __attribute__((section("PSP_TEXT_SEC")))
-#define D_PSP_DATA_SECTION                             __attribute__((section("PSP_DATA_SEC"), aligned(16)))
+#define D_PSP_DATA_SECTION                             __attribute__((section("PSP_DATA_SEC")))
 
 #define D_PSP_CREATE_ATTR(name, val)                   __attribute__((section(#name),aligned(val)))
 #define D_PSP_GENERAL_DATA_SECTION(name, align_avl)    D_PSP_CREATE_ATTR( (#name), align_avl )


### PR DESCRIPTION
align for psp data, fix bug for hifive1 that cause error/warning when linking
pass compilation for :

- comrv hifive1
- comrv swerv_eh1
- freertos hifive1 gcc
- freertos hifive1 llvm
- freertos swerv_eh1 gcc
- freertos swerv_eh1 llvm