### PR TITLE
Prebuild delete elf

### DIFF
--- a/WD-Firmware/demo/build/SConstruct
+++ b/WD-Firmware/demo/build/SConstruct
@@ -159,7 +159,6 @@ for strSconscript in objDemo.listSconscripts:
   arrLibs.append(SConscript(strSconscriptPrefix + '%s' % strSconscript, exports='Env'))
 
 #execute pre build actions
-#utils.fnCleanElf(Env['ELF_FILE'])
 Execute(Delete(Env['ELF_FILE']))
 
 

--- a/WD-Firmware/demo/build/SConstruct
+++ b/WD-Firmware/demo/build/SConstruct
@@ -159,7 +159,7 @@ for strSconscript in objDemo.listSconscripts:
   arrLibs.append(SConscript(strSconscriptPrefix + '%s' % strSconscript, exports='Env'))
 
 #execute pre build actions
-AddPostAction(objBundle, Action(utils.fnCleanElf))
+utils.fnCleanElf(Env['ELF_FILE'])
 
 
 objBundle = Env.Program(Env['ELF_FILE'], arrLibs, LIBS=Env['TARGET_LIBS'])

--- a/WD-Firmware/demo/build/SConstruct
+++ b/WD-Firmware/demo/build/SConstruct
@@ -159,7 +159,8 @@ for strSconscript in objDemo.listSconscripts:
   arrLibs.append(SConscript(strSconscriptPrefix + '%s' % strSconscript, exports='Env'))
 
 #execute pre build actions
-utils.fnCleanElf(Env['ELF_FILE'])
+#utils.fnCleanElf(Env['ELF_FILE'])
+Execute(Delete(Env['ELF_FILE']))
 
 
 objBundle = Env.Program(Env['ELF_FILE'], arrLibs, LIBS=Env['TARGET_LIBS'])

--- a/WD-Firmware/demo/build/SConstruct
+++ b/WD-Firmware/demo/build/SConstruct
@@ -158,6 +158,10 @@ print strEndHeader
 for strSconscript in objDemo.listSconscripts:
   arrLibs.append(SConscript(strSconscriptPrefix + '%s' % strSconscript, exports='Env'))
 
+#execute pre build actions
+AddPostAction(objBundle, Action(utils.fnCleanElf))
+
+
 objBundle = Env.Program(Env['ELF_FILE'], arrLibs, LIBS=Env['TARGET_LIBS'])
 # execute post build actions
 # todo:" to check depend soultion

--- a/WD-Firmware/demo/build/utils.py
+++ b/WD-Firmware/demo/build/utils.py
@@ -76,7 +76,6 @@ def fnProduceSectionsSize(target, source, env):
    f.close()
    return None
 
-
 # create the dump file
 def fnProduceDump(target, source, env):
    strDmpName     = env['DMP_FILE']

--- a/WD-Firmware/demo/build/utils.py
+++ b/WD-Firmware/demo/build/utils.py
@@ -32,11 +32,13 @@ STR_MAP_SIZE_APPEND = "%s %s >> %s"
 ##### Dependencies check
 STR_LIST_PKGS = "dpkg -s %s > tmp.txt 2>&1"
 STR_TMP_FILE = "tmp.txt"
-STR_PLATFORM_LINUX = "Linux"
-STR_PLATFORM_WIN = "Windows"
+STR_PLATFORM = "Linux"
 STR_NO_INSTALL = "not installed"
-STR_REMOVE_FILE_LINUX = "rm %s"
-STR_REMOVE_FILE_WIN = "del %s"
+if platform.uname()[0] == STR_PLATFORM:
+    STR_REMOVE_FILE = "rm %s"
+else:
+    STR_REMOVE_FILE = "del %s"
+    
 
 STR_TC_LLVM                  = "llvm"
 STR_BINUTILS                 = "binutils"
@@ -77,12 +79,9 @@ def fnProduceSectionsSize(target, source, env):
 # delete/clean elf file from prev build
 def fnCleanElf(strFileWithPatg):
    if os.path.exists(strFileWithPatg):
-     if platform.uname()[0] == STR_PLATFORM_LINUX:
-       fnExecuteCommand(STR_REMOVE_FILE_LINUX % strFileWithPatg, "unable to delete file " + strFileWithPatg)
-     else:
-       fnExecuteCommand(STR_REMOVE_FILE_WIN % strFileWithPatg, "unable to delete file " + strFileWithPatg)
+     fnExecuteCommand(STR_REMOVE_FILE % strFileWithPatg, "unable to delete file " + strFileWithPatg)
    else:
-       "no elf file to delete"  
+      print ("no elf file to delete")  
 
 
 # create the dump file
@@ -139,21 +138,22 @@ def fnCopyOverlaySection(target, source, env):
          print "'%s' is too small [%s] while '%s' size is [%s]" %(STR_RESERVED_OVL_SEC_NAME, hex(intReservedSectionSize), STR_OVL_DATA_SEC_NAME, hex(intOvlSectionSize))
          fnExecuteCommand("rm " + env['ELF_FILE'])
    # delete the temporary file
-   fnExecuteCommand(STR_REMOVE_FILE_LINUX % STR_TMP_FILE, "unable to delete temporary file")
+   fnExecuteCommand(STR_REMOVE_FILE % STR_TMP_FILE, "unable to delete temporary file")
    
    return None
 
+#TODO[OS]: we need to see if this is needed for Windows
 # under linux, verify installation dependencies
 def fnCheckInstalledDependencis(listDependencis):
-  if platform.uname()[0] == STR_PLATFORM_LINUX:
+  if platform.uname()[0] == STR_PLATFORM:
     for strDependency in listDependencis:
       fnExecuteCommand(STR_LIST_PKGS % strDependency, "dpkg failed executing")
       if STR_NO_INSTALL in open(STR_TMP_FILE).read():
         print("Error: please install missing library - " + strDependency)
-        fnExecuteCommand(STR_REMOVE_FILE_LINUX % STR_TMP_FILE)
+        fnExecuteCommand(STR_REMOVE_FILE % STR_TMP_FILE)
         exit(1)
 
-    fnExecuteCommand(STR_REMOVE_FILE_LINUX % STR_TMP_FILE, "Remove temporary file failed")
+    fnExecuteCommand(STR_REMOVE_FILE % STR_TMP_FILE, "Remove temporary file failed")
   else: 
     # currently only linux is supported 
     print("unsupported environment, please switch to a linux based machine")

--- a/WD-Firmware/demo/build/utils.py
+++ b/WD-Firmware/demo/build/utils.py
@@ -73,16 +73,16 @@ def fnProduceSectionsSize(target, source, env):
    f.close()
    return None
 
-# delete/clean elf file from prev build
-def fnCleanElf(target, source, env):
 
 # delete/clean elf file from prev build
-def fnCleanElf(target, source, env):
-   if platform.uname()[0] == STR_PLATFORM_LINUX:
-     fnExecuteCommand(STR_REMOVE_FILE_LINUX % Env['ELF_FILE'], "unable to delete file " + Env['ELF_FILE'])
+def fnCleanElf(strFileWithPatg):
+   if os.path.exists(strFileWithPatg):
+     if platform.uname()[0] == STR_PLATFORM_LINUX:
+       fnExecuteCommand(STR_REMOVE_FILE_LINUX % strFileWithPatg, "unable to delete file " + strFileWithPatg)
+     else:
+       fnExecuteCommand(STR_REMOVE_FILE_WIN % strFileWithPatg, "unable to delete file " + strFileWithPatg)
    else:
-     fnExecuteCommand(STR_REMOVE_FILE_WIN % Env['ELF_FILE'], "unable to delete file " + Env['ELF_FILE'])
-         
+       "no elf file to delete"  
 
 
 # create the dump file

--- a/WD-Firmware/demo/build/utils.py
+++ b/WD-Firmware/demo/build/utils.py
@@ -34,6 +34,7 @@ STR_LIST_PKGS = "dpkg -s %s > tmp.txt 2>&1"
 STR_TMP_FILE = "tmp.txt"
 STR_PLATFORM = "Linux"
 STR_NO_INSTALL = "not installed"
+#todo : consider using SCons API: Execute(Delete("the file))
 if platform.uname()[0] == STR_PLATFORM:
     STR_REMOVE_FILE = "rm %s"
 else:
@@ -74,14 +75,6 @@ def fnProduceSectionsSize(target, source, env):
       fnExecuteCommand(STR_MAP_SIZE_APPEND % (strSizeUtilName, strElfName, env['MAP_FILE']))
    f.close()
    return None
-
-
-# delete/clean elf file from prev build
-def fnCleanElf(strFileWithPatg):
-   if os.path.exists(strFileWithPatg):
-     fnExecuteCommand(STR_REMOVE_FILE % strFileWithPatg, "unable to delete file " + strFileWithPatg)
-   else:
-      print ("no elf file to delete")  
 
 
 # create the dump file

--- a/WD-Firmware/demo/build/utils.py
+++ b/WD-Firmware/demo/build/utils.py
@@ -32,9 +32,11 @@ STR_MAP_SIZE_APPEND = "%s %s >> %s"
 ##### Dependencies check
 STR_LIST_PKGS = "dpkg -s %s > tmp.txt 2>&1"
 STR_TMP_FILE = "tmp.txt"
-STR_PLATFORM = "Linux"
+STR_PLATFORM_LINUX = "Linux"
+STR_PLATFORM_WIN = "Windows"
 STR_NO_INSTALL = "not installed"
-STR_REMOVE_FILE = "rm %s"
+STR_REMOVE_FILE_LINUX = "rm %s"
+STR_REMOVE_FILE_WIN = "del %s"
 
 STR_TC_LLVM                  = "llvm"
 STR_BINUTILS                 = "binutils"
@@ -70,6 +72,18 @@ def fnProduceSectionsSize(target, source, env):
       fnExecuteCommand(STR_MAP_SIZE_APPEND % (strSizeUtilName, strElfName, env['MAP_FILE']))
    f.close()
    return None
+
+# delete/clean elf file from prev build
+def fnCleanElf(target, source, env):
+
+# delete/clean elf file from prev build
+def fnCleanElf(target, source, env):
+   if platform.uname()[0] == STR_PLATFORM_LINUX:
+     fnExecuteCommand(STR_REMOVE_FILE_LINUX % Env['ELF_FILE'], "unable to delete file " + Env['ELF_FILE'])
+   else:
+     fnExecuteCommand(STR_REMOVE_FILE_WIN % Env['ELF_FILE'], "unable to delete file " + Env['ELF_FILE'])
+         
+
 
 # create the dump file
 def fnProduceDump(target, source, env):
@@ -125,21 +139,21 @@ def fnCopyOverlaySection(target, source, env):
          print "'%s' is too small [%s] while '%s' size is [%s]" %(STR_RESERVED_OVL_SEC_NAME, hex(intReservedSectionSize), STR_OVL_DATA_SEC_NAME, hex(intOvlSectionSize))
          fnExecuteCommand("rm " + env['ELF_FILE'])
    # delete the temporary file
-   fnExecuteCommand(STR_REMOVE_FILE % STR_TMP_FILE, "unable to delete temporary file")
+   fnExecuteCommand(STR_REMOVE_FILE_LINUX % STR_TMP_FILE, "unable to delete temporary file")
    
    return None
 
 # under linux, verify installation dependencies
 def fnCheckInstalledDependencis(listDependencis):
-  if platform.uname()[0] == STR_PLATFORM:
+  if platform.uname()[0] == STR_PLATFORM_LINUX:
     for strDependency in listDependencis:
       fnExecuteCommand(STR_LIST_PKGS % strDependency, "dpkg failed executing")
       if STR_NO_INSTALL in open(STR_TMP_FILE).read():
         print("Error: please install missing library - " + strDependency)
-        fnExecuteCommand(STR_REMOVE_FILE % STR_TMP_FILE)
+        fnExecuteCommand(STR_REMOVE_FILE_LINUX % STR_TMP_FILE)
         exit(1)
 
-    fnExecuteCommand(STR_REMOVE_FILE % STR_TMP_FILE, "Remove temporary file failed")
+    fnExecuteCommand(STR_REMOVE_FILE_LINUX % STR_TMP_FILE, "Remove temporary file failed")
   else: 
     # currently only linux is supported 
     print("unsupported environment, please switch to a linux based machine")


### PR DESCRIPTION
adding delete function to sconstruct. The function will delete the elf files before build, if exist. This is for times when we modify the ld script and we need to link again 